### PR TITLE
Disable x-checker until maintainer activity resumes

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-    "only-arches": ["x86_64"]
+    "only-arches": ["x86_64"],
+    "disable-external-data-checker": true
 }


### PR DESCRIPTION
Rust nightly also should be consumed from the SDK extension and applications should not be adding tarballs to their manifest unless necessary.

Also, there has been no maintainer activity for more than 2 months while the CI is being used daily to make failing rust nightly update PRs.



Maintainer's were pinged https://github.com/flathub/org.mfek.MFEKglif/pull/47#issuecomment-1925066441

Feel free to remove this when maintenance is resumed. Please ping me if you need any help.