### PR TITLE
Update to latest revision, enable building for aarch64

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-    "only-arches": ["x86_64"],
     "disable-external-data-checker": true
 }

--- a/generated-sources.json
+++ b/generated-sources.json
@@ -2,8 +2,8 @@
     {
         "type": "git",
         "url": "https://github.com/mfek/math.rlib",
-        "commit": "1bccb33e9d8a3f6bde9ea234b7519384bc050526",
-        "dest": "flatpak-cargo/git/math.rlib-1bccb33"
+        "commit": "32e23560f8c5b5d912a9ed4c23a8924acab9b462",
+        "dest": "flatpak-cargo/git/math.rlib-32e2356"
     },
     {
         "type": "git",
@@ -13,15 +13,33 @@
     },
     {
         "type": "git",
+        "url": "https://github.com/mfek/egui.rlib",
+        "commit": "307565efa55158cfa6b82d2e8fdc4c4914b954ed",
+        "dest": "flatpak-cargo/git/egui.rlib-307565e"
+    },
+    {
+        "type": "git",
+        "url": "https://github.com/mfek/egui-sdl2-event.rlib",
+        "commit": "03e0def7dfa6ca30d7c9dedf70ace22125d66b88",
+        "dest": "flatpak-cargo/git/egui-sdl2-event.rlib-03e0def"
+    },
+    {
+        "type": "git",
+        "url": "https://github.com/mfek/egui_skia.rlib",
+        "commit": "bad5157d28a978ca19440c6d7b5ad5822ad10e83",
+        "dest": "flatpak-cargo/git/egui_skia.rlib-bad5157"
+    },
+    {
+        "type": "git",
         "url": "https://github.com/mfek/glifparser.rlib",
-        "commit": "f8dcacbcaed2632e6287f32872bf1ab3b6174cfb",
-        "dest": "flatpak-cargo/git/glifparser.rlib-f8dcacb"
+        "commit": "c642cc8ea7386ceb7f91ee65bd01c57e0a2cc58e",
+        "dest": "flatpak-cargo/git/glifparser.rlib-c642cc8"
     },
     {
         "type": "git",
         "url": "https://github.com/mfek/glifrenderer.rlib",
-        "commit": "044324a0fa7cc90c8cd4b25cac40ffa5494a85ee",
-        "dest": "flatpak-cargo/git/glifrenderer.rlib-044324a"
+        "commit": "7fd9b9ee48227673d7fb242c90b8883f010f017d",
+        "dest": "flatpak-cargo/git/glifrenderer.rlib-7fd9b9e"
     },
     {
         "type": "git",
@@ -43,9 +61,21 @@
     },
     {
         "type": "git",
+        "url": "https://github.com/servo/pathfinder",
+        "commit": "30419d07660dc11a21e42ef4a7fa329600cff152",
+        "dest": "flatpak-cargo/git/pathfinder-30419d0"
+    },
+    {
+        "type": "git",
         "url": "https://github.com/mfek/pub_mod.rlib",
         "commit": "511b208ed772999d7fd63b250385dfab439794b9",
         "dest": "flatpak-cargo/git/pub_mod.rlib-511b208"
+    },
+    {
+        "type": "git",
+        "url": "https://github.com/john01dav/softbuffer",
+        "commit": "5c7a2099e00a6c5e1e8eb3f65f05596a3f1c6db2",
+        "dest": "flatpak-cargo/git/softbuffer-5c7a209"
     },
     {
         "type": "git",
@@ -56,8 +86,8 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p cargo/vendor",
-            "cp -r --reflink=auto \"flatpak-cargo/git/math.rlib-1bccb33/.\" \"cargo/vendor/MFEKmath\""
+            "mkdir -p cargo/vendor/MFEKmath",
+            "cp -r --reflink=auto \"flatpak-cargo/git/math.rlib-32e2356/.\" \"cargo/vendor/MFEKmath\""
         ]
     },
     {
@@ -75,14 +105,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ab_glyph/ab_glyph-0.2.21.crate",
-        "sha256": "5110f1c78cf582855d895ecd0746b653db010cec6d9f5575293f27934d980a39",
-        "dest": "cargo/vendor/ab_glyph-0.2.21"
+        "url": "https://static.crates.io/crates/ab_glyph/ab_glyph-0.2.23.crate",
+        "sha256": "80179d7dd5d7e8c285d67c4a1e652972a92de7475beddfb92028c76463b13225",
+        "dest": "cargo/vendor/ab_glyph-0.2.23"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5110f1c78cf582855d895ecd0746b653db010cec6d9f5575293f27934d980a39\", \"files\": {}}",
-        "dest": "cargo/vendor/ab_glyph-0.2.21",
+        "contents": "{\"package\": \"80179d7dd5d7e8c285d67c4a1e652972a92de7475beddfb92028c76463b13225\", \"files\": {}}",
+        "dest": "cargo/vendor/ab_glyph-0.2.23",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -140,27 +170,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ahash/ahash-0.8.3.crate",
-        "sha256": "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f",
-        "dest": "cargo/vendor/ahash-0.8.3"
+        "url": "https://static.crates.io/crates/ahash/ahash-0.8.11.crate",
+        "sha256": "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011",
+        "dest": "cargo/vendor/ahash-0.8.11"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f\", \"files\": {}}",
-        "dest": "cargo/vendor/ahash-0.8.3",
+        "contents": "{\"package\": \"e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011\", \"files\": {}}",
+        "dest": "cargo/vendor/ahash-0.8.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/aho-corasick/aho-corasick-1.0.5.crate",
-        "sha256": "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783",
-        "dest": "cargo/vendor/aho-corasick-1.0.5"
+        "url": "https://static.crates.io/crates/aho-corasick/aho-corasick-1.1.3.crate",
+        "sha256": "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916",
+        "dest": "cargo/vendor/aho-corasick-1.1.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783\", \"files\": {}}",
-        "dest": "cargo/vendor/aho-corasick-1.0.5",
+        "contents": "{\"package\": \"8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916\", \"files\": {}}",
+        "dest": "cargo/vendor/aho-corasick-1.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -205,14 +235,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.75.crate",
-        "sha256": "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6",
-        "dest": "cargo/vendor/anyhow-1.0.75"
+        "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.81.crate",
+        "sha256": "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247",
+        "dest": "cargo/vendor/anyhow-1.0.81"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6\", \"files\": {}}",
-        "dest": "cargo/vendor/anyhow-1.0.75",
+        "contents": "{\"package\": \"0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247\", \"files\": {}}",
+        "dest": "cargo/vendor/anyhow-1.0.81",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -244,6 +274,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/as-raw-xcb-connection/as-raw-xcb-connection-1.0.1.crate",
+        "sha256": "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b",
+        "dest": "cargo/vendor/as-raw-xcb-connection-1.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b\", \"files\": {}}",
+        "dest": "cargo/vendor/as-raw-xcb-connection-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/atk/atk-0.9.0.crate",
         "sha256": "812b4911e210bd51b24596244523c856ca749e6223c50a7fbbba3f89ee37c426",
         "dest": "cargo/vendor/atk-0.9.0"
@@ -270,14 +313,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/atomic_refcell/atomic_refcell-0.1.11.crate",
-        "sha256": "112ef6b3f6cb3cb6fc5b6b494ef7a848492cff1ab0ef4de10b0f7d572861c905",
-        "dest": "cargo/vendor/atomic_refcell-0.1.11"
+        "url": "https://static.crates.io/crates/atomic_refcell/atomic_refcell-0.1.13.crate",
+        "sha256": "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c",
+        "dest": "cargo/vendor/atomic_refcell-0.1.13"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"112ef6b3f6cb3cb6fc5b6b494ef7a848492cff1ab0ef4de10b0f7d572861c905\", \"files\": {}}",
-        "dest": "cargo/vendor/atomic_refcell-0.1.11",
+        "contents": "{\"package\": \"41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c\", \"files\": {}}",
+        "dest": "cargo/vendor/atomic_refcell-0.1.13",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -296,53 +339,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/autocfg/autocfg-1.1.0.crate",
-        "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
-        "dest": "cargo/vendor/autocfg-1.1.0"
+        "url": "https://static.crates.io/crates/autocfg/autocfg-1.2.0.crate",
+        "sha256": "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80",
+        "dest": "cargo/vendor/autocfg-1.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa\", \"files\": {}}",
-        "dest": "cargo/vendor/autocfg-1.1.0",
+        "contents": "{\"package\": \"f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80\", \"files\": {}}",
+        "dest": "cargo/vendor/autocfg-1.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/backtrace/backtrace-0.3.69.crate",
-        "sha256": "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837",
-        "dest": "cargo/vendor/backtrace-0.3.69"
+        "url": "https://static.crates.io/crates/backtrace/backtrace-0.3.71.crate",
+        "sha256": "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d",
+        "dest": "cargo/vendor/backtrace-0.3.71"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837\", \"files\": {}}",
-        "dest": "cargo/vendor/backtrace-0.3.69",
+        "contents": "{\"package\": \"26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d\", \"files\": {}}",
+        "dest": "cargo/vendor/backtrace-0.3.71",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/base64/base64-0.21.3.crate",
-        "sha256": "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53",
-        "dest": "cargo/vendor/base64-0.21.3"
+        "url": "https://static.crates.io/crates/base64/base64-0.21.7.crate",
+        "sha256": "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567",
+        "dest": "cargo/vendor/base64-0.21.7"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53\", \"files\": {}}",
-        "dest": "cargo/vendor/base64-0.21.3",
+        "contents": "{\"package\": \"9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567\", \"files\": {}}",
+        "dest": "cargo/vendor/base64-0.21.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bindgen/bindgen-0.65.1.crate",
-        "sha256": "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5",
-        "dest": "cargo/vendor/bindgen-0.65.1"
+        "url": "https://static.crates.io/crates/bindgen/bindgen-0.69.4.crate",
+        "sha256": "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0",
+        "dest": "cargo/vendor/bindgen-0.69.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5\", \"files\": {}}",
-        "dest": "cargo/vendor/bindgen-0.65.1",
+        "contents": "{\"package\": \"a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0\", \"files\": {}}",
+        "dest": "cargo/vendor/bindgen-0.69.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -361,14 +404,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bitflags/bitflags-2.4.0.crate",
-        "sha256": "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635",
-        "dest": "cargo/vendor/bitflags-2.4.0"
+        "url": "https://static.crates.io/crates/bitflags/bitflags-2.5.0.crate",
+        "sha256": "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1",
+        "dest": "cargo/vendor/bitflags-2.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635\", \"files\": {}}",
-        "dest": "cargo/vendor/bitflags-2.4.0",
+        "contents": "{\"package\": \"cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1\", \"files\": {}}",
+        "dest": "cargo/vendor/bitflags-2.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -387,40 +430,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bumpalo/bumpalo-3.13.0.crate",
-        "sha256": "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1",
-        "dest": "cargo/vendor/bumpalo-3.13.0"
+        "url": "https://static.crates.io/crates/bumpalo/bumpalo-3.15.4.crate",
+        "sha256": "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa",
+        "dest": "cargo/vendor/bumpalo-3.15.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1\", \"files\": {}}",
-        "dest": "cargo/vendor/bumpalo-3.13.0",
+        "contents": "{\"package\": \"7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa\", \"files\": {}}",
+        "dest": "cargo/vendor/bumpalo-3.15.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bytemuck/bytemuck-1.13.1.crate",
-        "sha256": "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea",
-        "dest": "cargo/vendor/bytemuck-1.13.1"
+        "url": "https://static.crates.io/crates/bytemuck/bytemuck-1.15.0.crate",
+        "sha256": "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15",
+        "dest": "cargo/vendor/bytemuck-1.15.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea\", \"files\": {}}",
-        "dest": "cargo/vendor/bytemuck-1.13.1",
+        "contents": "{\"package\": \"5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15\", \"files\": {}}",
+        "dest": "cargo/vendor/bytemuck-1.15.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/byteorder/byteorder-1.4.3.crate",
-        "sha256": "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610",
-        "dest": "cargo/vendor/byteorder-1.4.3"
+        "url": "https://static.crates.io/crates/bytemuck_derive/bytemuck_derive-1.6.0.crate",
+        "sha256": "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60",
+        "dest": "cargo/vendor/bytemuck_derive-1.6.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610\", \"files\": {}}",
-        "dest": "cargo/vendor/byteorder-1.4.3",
+        "contents": "{\"package\": \"4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60\", \"files\": {}}",
+        "dest": "cargo/vendor/bytemuck_derive-1.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/byteorder/byteorder-1.5.0.crate",
+        "sha256": "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b",
+        "dest": "cargo/vendor/byteorder-1.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b\", \"files\": {}}",
+        "dest": "cargo/vendor/byteorder-1.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -465,14 +521,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cc/cc-1.0.83.crate",
-        "sha256": "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0",
-        "dest": "cargo/vendor/cc-1.0.83"
+        "url": "https://static.crates.io/crates/cc/cc-1.0.90.crate",
+        "sha256": "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5",
+        "dest": "cargo/vendor/cc-1.0.90"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0\", \"files\": {}}",
-        "dest": "cargo/vendor/cc-1.0.83",
+        "contents": "{\"package\": \"8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5\", \"files\": {}}",
+        "dest": "cargo/vendor/cc-1.0.90",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -504,14 +560,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/chrono/chrono-0.4.28.crate",
-        "sha256": "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f",
-        "dest": "cargo/vendor/chrono-0.4.28"
+        "url": "https://static.crates.io/crates/cfg_aliases/cfg_aliases-0.1.1.crate",
+        "sha256": "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e",
+        "dest": "cargo/vendor/cfg_aliases-0.1.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f\", \"files\": {}}",
-        "dest": "cargo/vendor/chrono-0.4.28",
+        "contents": "{\"package\": \"fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg_aliases-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfg_aliases/cfg_aliases-0.2.0.crate",
+        "sha256": "77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f",
+        "dest": "cargo/vendor/cfg_aliases-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg_aliases-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/chrono/chrono-0.4.31.crate",
+        "sha256": "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38",
+        "dest": "cargo/vendor/chrono-0.4.31"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38\", \"files\": {}}",
+        "dest": "cargo/vendor/chrono-0.4.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -535,14 +617,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/clang-sys/clang-sys-1.6.1.crate",
-        "sha256": "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f",
-        "dest": "cargo/vendor/clang-sys-1.6.1"
+        "url": "https://static.crates.io/crates/clang-sys/clang-sys-1.7.0.crate",
+        "sha256": "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1",
+        "dest": "cargo/vendor/clang-sys-1.7.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f\", \"files\": {}}",
-        "dest": "cargo/vendor/clang-sys-1.6.1",
+        "contents": "{\"package\": \"67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1\", \"files\": {}}",
+        "dest": "cargo/vendor/clang-sys-1.7.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -613,14 +695,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cocoa-foundation/cocoa-foundation-0.1.1.crate",
-        "sha256": "931d3837c286f56e3c58423ce4eba12d08db2374461a785c86f672b08b5650d6",
-        "dest": "cargo/vendor/cocoa-foundation-0.1.1"
+        "url": "https://static.crates.io/crates/cocoa/cocoa-0.25.0.crate",
+        "sha256": "f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c",
+        "dest": "cargo/vendor/cocoa-0.25.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"931d3837c286f56e3c58423ce4eba12d08db2374461a785c86f672b08b5650d6\", \"files\": {}}",
-        "dest": "cargo/vendor/cocoa-foundation-0.1.1",
+        "contents": "{\"package\": \"f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c\", \"files\": {}}",
+        "dest": "cargo/vendor/cocoa-0.25.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cocoa-foundation/cocoa-foundation-0.1.2.crate",
+        "sha256": "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7",
+        "dest": "cargo/vendor/cocoa-foundation-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7\", \"files\": {}}",
+        "dest": "cargo/vendor/cocoa-foundation-0.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -639,14 +734,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/colored/colored-2.0.4.crate",
-        "sha256": "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6",
-        "dest": "cargo/vendor/colored-2.0.4"
+        "url": "https://static.crates.io/crates/colored/colored-2.1.0.crate",
+        "sha256": "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8",
+        "dest": "cargo/vendor/colored-2.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6\", \"files\": {}}",
-        "dest": "cargo/vendor/colored-2.0.4",
+        "contents": "{\"package\": \"cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8\", \"files\": {}}",
+        "dest": "cargo/vendor/colored-2.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -665,27 +760,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/core-foundation/core-foundation-0.9.3.crate",
-        "sha256": "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146",
-        "dest": "cargo/vendor/core-foundation-0.9.3"
+        "url": "https://static.crates.io/crates/core-foundation/core-foundation-0.9.4.crate",
+        "sha256": "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f",
+        "dest": "cargo/vendor/core-foundation-0.9.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146\", \"files\": {}}",
-        "dest": "cargo/vendor/core-foundation-0.9.3",
+        "contents": "{\"package\": \"91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f\", \"files\": {}}",
+        "dest": "cargo/vendor/core-foundation-0.9.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.8.4.crate",
-        "sha256": "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa",
-        "dest": "cargo/vendor/core-foundation-sys-0.8.4"
+        "url": "https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.8.6.crate",
+        "sha256": "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f",
+        "dest": "cargo/vendor/core-foundation-sys-0.8.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa\", \"files\": {}}",
-        "dest": "cargo/vendor/core-foundation-sys-0.8.4",
+        "contents": "{\"package\": \"06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f\", \"files\": {}}",
+        "dest": "cargo/vendor/core-foundation-sys-0.8.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -704,14 +799,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/core-graphics-types/core-graphics-types-0.1.2.crate",
-        "sha256": "2bb142d41022986c1d8ff29103a1411c8a3dfad3552f87a4f8dc50d61d4f4e33",
-        "dest": "cargo/vendor/core-graphics-types-0.1.2"
+        "url": "https://static.crates.io/crates/core-graphics/core-graphics-0.23.1.crate",
+        "sha256": "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212",
+        "dest": "cargo/vendor/core-graphics-0.23.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2bb142d41022986c1d8ff29103a1411c8a3dfad3552f87a4f8dc50d61d4f4e33\", \"files\": {}}",
-        "dest": "cargo/vendor/core-graphics-types-0.1.2",
+        "contents": "{\"package\": \"970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212\", \"files\": {}}",
+        "dest": "cargo/vendor/core-graphics-0.23.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-graphics-types/core-graphics-types-0.1.3.crate",
+        "sha256": "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf",
+        "dest": "cargo/vendor/core-graphics-types-0.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf\", \"files\": {}}",
+        "dest": "cargo/vendor/core-graphics-types-0.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -730,53 +838,66 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/crc32fast/crc32fast-1.3.2.crate",
-        "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
-        "dest": "cargo/vendor/crc32fast-1.3.2"
+        "url": "https://static.crates.io/crates/crc32fast/crc32fast-1.4.0.crate",
+        "sha256": "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa",
+        "dest": "cargo/vendor/crc32fast-1.4.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d\", \"files\": {}}",
-        "dest": "cargo/vendor/crc32fast-1.3.2",
+        "contents": "{\"package\": \"b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa\", \"files\": {}}",
+        "dest": "cargo/vendor/crc32fast-1.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/crossbeam-channel/crossbeam-channel-0.5.8.crate",
-        "sha256": "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200",
-        "dest": "cargo/vendor/crossbeam-channel-0.5.8"
+        "url": "https://static.crates.io/crates/crossbeam-channel/crossbeam-channel-0.5.12.crate",
+        "sha256": "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95",
+        "dest": "cargo/vendor/crossbeam-channel-0.5.12"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200\", \"files\": {}}",
-        "dest": "cargo/vendor/crossbeam-channel-0.5.8",
+        "contents": "{\"package\": \"ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-channel-0.5.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.8.16.crate",
-        "sha256": "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294",
-        "dest": "cargo/vendor/crossbeam-utils-0.8.16"
+        "url": "https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.8.19.crate",
+        "sha256": "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345",
+        "dest": "cargo/vendor/crossbeam-utils-0.8.19"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294\", \"files\": {}}",
-        "dest": "cargo/vendor/crossbeam-utils-0.8.16",
+        "contents": "{\"package\": \"248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-utils-0.8.19",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ctrlc/ctrlc-3.4.0.crate",
-        "sha256": "2a011bbe2c35ce9c1f143b7af6f94f29a167beb4cd1d29e6740ce836f723120e",
-        "dest": "cargo/vendor/ctrlc-3.4.0"
+        "url": "https://static.crates.io/crates/ctor/ctor-0.2.7.crate",
+        "sha256": "ad291aa74992b9b7a7e88c38acbbf6ad7e107f1d90ee8775b7bc1fc3394f485c",
+        "dest": "cargo/vendor/ctor-0.2.7"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2a011bbe2c35ce9c1f143b7af6f94f29a167beb4cd1d29e6740ce836f723120e\", \"files\": {}}",
-        "dest": "cargo/vendor/ctrlc-3.4.0",
+        "contents": "{\"package\": \"ad291aa74992b9b7a7e88c38acbbf6ad7e107f1d90ee8775b7bc1fc3394f485c\", \"files\": {}}",
+        "dest": "cargo/vendor/ctor-0.2.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ctrlc/ctrlc-3.4.4.crate",
+        "sha256": "672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345",
+        "dest": "cargo/vendor/ctrlc-3.4.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345\", \"files\": {}}",
+        "dest": "cargo/vendor/ctrlc-3.4.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -808,14 +929,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/deranged/deranged-0.3.8.crate",
-        "sha256": "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946",
-        "dest": "cargo/vendor/deranged-0.3.8"
+        "url": "https://static.crates.io/crates/deranged/deranged-0.3.11.crate",
+        "sha256": "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4",
+        "dest": "cargo/vendor/deranged-0.3.11"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946\", \"files\": {}}",
-        "dest": "cargo/vendor/deranged-0.3.8",
+        "contents": "{\"package\": \"b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4\", \"files\": {}}",
+        "dest": "cargo/vendor/deranged-0.3.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -899,6 +1020,84 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dlib/dlib-0.5.2.crate",
+        "sha256": "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412",
+        "dest": "cargo/vendor/dlib-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412\", \"files\": {}}",
+        "dest": "cargo/vendor/dlib-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/downcast-rs/downcast-rs-1.2.0.crate",
+        "sha256": "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650",
+        "dest": "cargo/vendor/downcast-rs-1.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650\", \"files\": {}}",
+        "dest": "cargo/vendor/downcast-rs-1.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/drm/drm-0.11.1.crate",
+        "sha256": "a0f8a69e60d75ae7dab4ef26a59ca99f2a89d4c142089b537775ae0c198bdcde",
+        "dest": "cargo/vendor/drm-0.11.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a0f8a69e60d75ae7dab4ef26a59ca99f2a89d4c142089b537775ae0c198bdcde\", \"files\": {}}",
+        "dest": "cargo/vendor/drm-0.11.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/drm-ffi/drm-ffi-0.7.1.crate",
+        "sha256": "41334f8405792483e32ad05fbb9c5680ff4e84491883d2947a4757dc54cb2ac6",
+        "dest": "cargo/vendor/drm-ffi-0.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"41334f8405792483e32ad05fbb9c5680ff4e84491883d2947a4757dc54cb2ac6\", \"files\": {}}",
+        "dest": "cargo/vendor/drm-ffi-0.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/drm-fourcc/drm-fourcc-2.2.0.crate",
+        "sha256": "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4",
+        "dest": "cargo/vendor/drm-fourcc-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4\", \"files\": {}}",
+        "dest": "cargo/vendor/drm-fourcc-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/drm-sys/drm-sys-0.6.1.crate",
+        "sha256": "2d09ff881f92f118b11105ba5e34ff8f4adf27b30dae8f12e28c193af1c83176",
+        "dest": "cargo/vendor/drm-sys-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2d09ff881f92f118b11105ba5e34ff8f4adf27b30dae8f12e28c193af1c83176\", \"files\": {}}",
+        "dest": "cargo/vendor/drm-sys-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/dwrote/dwrote-0.11.0.crate",
         "sha256": "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b",
         "dest": "cargo/vendor/dwrote-0.11.0"
@@ -912,92 +1111,182 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/dyn-clone/dyn-clone-1.0.13.crate",
-        "sha256": "bbfc4744c1b8f2a09adc0e55242f60b1af195d88596bd8700be74418c056c555",
-        "dest": "cargo/vendor/dyn-clone-1.0.13"
+        "url": "https://static.crates.io/crates/dyn-clone/dyn-clone-1.0.17.crate",
+        "sha256": "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125",
+        "dest": "cargo/vendor/dyn-clone-1.0.17"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bbfc4744c1b8f2a09adc0e55242f60b1af195d88596bd8700be74418c056c555\", \"files\": {}}",
-        "dest": "cargo/vendor/dyn-clone-1.0.13",
+        "contents": "{\"package\": \"0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125\", \"files\": {}}",
+        "dest": "cargo/vendor/dyn-clone-1.0.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ecolor/ecolor-0.22.0.crate",
-        "sha256": "2e479a7fa3f23d4e794f8b2f8b3568dd4e47886ad1b12c9c095e141cb591eb63",
-        "dest": "cargo/vendor/ecolor-0.22.0"
+        "url": "https://static.crates.io/crates/ecolor/ecolor-0.21.0.crate",
+        "sha256": "1f99fe3cac305af9d6d92971af60d0f7ea4d783201ef1673571567b6699964d9",
+        "dest": "cargo/vendor/ecolor-0.21.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2e479a7fa3f23d4e794f8b2f8b3568dd4e47886ad1b12c9c095e141cb591eb63\", \"files\": {}}",
-        "dest": "cargo/vendor/ecolor-0.22.0",
+        "contents": "{\"package\": \"1f99fe3cac305af9d6d92971af60d0f7ea4d783201ef1673571567b6699964d9\", \"files\": {}}",
+        "dest": "cargo/vendor/ecolor-0.21.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "cp -r --reflink=auto \"flatpak-cargo/git/egui.rlib-307565e/crates/ecolor\" \"cargo/vendor/ecolor\""
+        ]
+    },
+    {
+        "type": "inline",
+        "contents": "[package]\nname = \"ecolor\"\nversion = \"0.22.0\"\nauthors = [ \"Emil Ernerfeldt <emil.ernerfeldt@gmail.com>\", \"Andreas Reich <reichandreas@gmx.de>\",]\ndescription = \"Color structs and color conversion utilities\"\nedition = \"2021\"\nrust-version = \"1.65\"\nhomepage = \"https://github.com/emilk/egui\"\nlicense = \"MIT OR Apache-2.0\"\nreadme = \"README.md\"\nrepository = \"https://github.com/emilk/egui\"\ncategories = [ \"mathematics\", \"encoding\",]\nkeywords = [ \"gui\", \"color\", \"conversion\", \"gamedev\", \"images\",]\ninclude = [ \"../LICENSE-APACHE\", \"../LICENSE-MIT\", \"**/*.rs\", \"Cargo.toml\",]\n\n[lib]\n\n[features]\ndefault = []\nextra_debug_asserts = []\nextra_asserts = []\n\n[dependencies.bytemuck]\nversion = \"1.7.2\"\noptional = true\nfeatures = [ \"derive\",]\n\n[dependencies.cint]\nversion = \"0.3.1\"\noptional = true\n\n[dependencies.color-hex]\nversion = \"0.2.0\"\noptional = true\n\n[dependencies.document-features]\nversion = \"0.2\"\noptional = true\n\n[dependencies.serde]\nversion = \"1\"\noptional = true\nfeatures = [ \"derive\",]\n\n[package.metadata.docs.rs]\nall-features = true\n",
+        "dest": "cargo/vendor/ecolor",
+        "dest-filename": "Cargo.toml"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": null, \"files\": {}}",
+        "dest": "cargo/vendor/ecolor",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/egui/egui-0.22.0.crate",
-        "sha256": "a3aef8ec3ae1b772f340170c65bf27d5b8c28f543a0116c844d2ac08d01123e7",
-        "dest": "cargo/vendor/egui-0.22.0"
+        "url": "https://static.crates.io/crates/egui/egui-0.21.0.crate",
+        "sha256": "6412a21e0bde7c0918f7fb44bbbb86b5e1f88e63c026a4e747cc7af02f76dfbe",
+        "dest": "cargo/vendor/egui-0.21.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a3aef8ec3ae1b772f340170c65bf27d5b8c28f543a0116c844d2ac08d01123e7\", \"files\": {}}",
-        "dest": "cargo/vendor/egui-0.22.0",
+        "contents": "{\"package\": \"6412a21e0bde7c0918f7fb44bbbb86b5e1f88e63c026a4e747cc7af02f76dfbe\", \"files\": {}}",
+        "dest": "cargo/vendor/egui-0.21.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "cp -r --reflink=auto \"flatpak-cargo/git/egui.rlib-307565e/crates/egui\" \"cargo/vendor/egui\""
+        ]
+    },
+    {
+        "type": "inline",
+        "contents": "[package]\nname = \"egui\"\nversion = \"0.22.0\"\nauthors = [ \"Emil Ernerfeldt <emil.ernerfeldt@gmail.com>\",]\ndescription = \"An easy-to-use immediate mode GUI that runs on both web and native\"\nedition = \"2021\"\nrust-version = \"1.65\"\nhomepage = \"https://github.com/emilk/egui\"\nlicense = \"MIT OR Apache-2.0\"\nreadme = \"../../README.md\"\nrepository = \"https://github.com/emilk/egui\"\ncategories = [ \"gui\", \"game-development\",]\nkeywords = [ \"gui\", \"imgui\", \"immediate\", \"portable\", \"gamedev\",]\ninclude = [ \"../LICENSE-APACHE\", \"../LICENSE-MIT\", \"**/*.rs\", \"Cargo.toml\",]\n\n[lib]\n\n[features]\ndefault = [ \"default_fonts\",]\nbytemuck = [ \"epaint/bytemuck\",]\ncint = [ \"epaint/cint\",]\ncolor-hex = [ \"epaint/color-hex\",]\ndeadlock_detection = [ \"epaint/deadlock_detection\",]\ndefault_fonts = [ \"epaint/default_fonts\",]\nextra_debug_asserts = [ \"epaint/extra_debug_asserts\",]\nextra_asserts = [ \"epaint/extra_asserts\",]\nlog = [ \"dep:log\", \"epaint/log\",]\nmint = [ \"epaint/mint\",]\npersistence = [ \"serde\", \"epaint/serde\", \"ron\",]\nserde = [ \"dep:serde\", \"epaint/serde\", \"accesskit?/serde\",]\nunity = [ \"epaint/unity\",]\n\n[dependencies]\nnohash-hasher = \"0.2\"\n\n[dependencies.epaint]\nversion = \"0.22.0\"\npath = \"../epaint\"\ndefault-features = false\n\n[dependencies.ahash]\nversion = \"0.8.1\"\ndefault-features = false\nfeatures = [ \"no-rng\", \"std\",]\n\n[dependencies.accesskit]\nversion = \"0.11\"\noptional = true\n\n[dependencies.document-features]\nversion = \"0.2\"\noptional = true\n\n[dependencies.log]\nversion = \"0.4\"\noptional = true\nfeatures = [ \"std\",]\n\n[dependencies.ron]\nversion = \"0.8\"\noptional = true\n\n[dependencies.serde]\nversion = \"1\"\noptional = true\nfeatures = [ \"derive\", \"rc\",]\n\n[package.metadata.docs.rs]\nall-features = true\n",
+        "dest": "cargo/vendor/egui",
+        "dest-filename": "Cargo.toml"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": null, \"files\": {}}",
+        "dest": "cargo/vendor/egui",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "cp -r --reflink=auto \"flatpak-cargo/git/egui-sdl2-event.rlib-03e0def/egui-sdl2-event\" \"cargo/vendor/egui-sdl2-event\""
+        ]
+    },
+    {
+        "type": "inline",
+        "contents": "[package]\nname = \"egui-sdl2-event\"\nauthors = [ \"Valtteri Vallius\",]\nversion = \"0.3.0\"\nedition = \"2021\"\nkeywords = [ \"sdl2\", \"egui\",]\ncategories = [ \"gui\", \"input\",]\ndescription = \"Provides event handling for egui in SDL2 window applications.\"\nlicense = \"MIT\"\nreadme = \"README.md\"\nrepository = \"https://github.com/kaphula/egui-sdl2-event\"\nhomepage = \"https://github.com/kaphula/egui-sdl2-event\"\n\n[dependencies]\nsdl2 = \"0.35.2\"\n\n[dependencies.egui]\ngit = \"https://github.com/MFEK/egui.rlib\"\n",
+        "dest": "cargo/vendor/egui-sdl2-event",
+        "dest-filename": "Cargo.toml"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": null, \"files\": {}}",
+        "dest": "cargo/vendor/egui-sdl2-event",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/egui-skia-sdl2-event/egui-skia-sdl2-event-0.4.0.crate",
-        "sha256": "b46b0a20637084b34122d8f7875cdba0f08b77d270aa23be3fccb5f0a4637174",
-        "dest": "cargo/vendor/egui-skia-sdl2-event-0.4.0"
+        "url": "https://static.crates.io/crates/egui_demo_lib/egui_demo_lib-0.21.0.crate",
+        "sha256": "86ac92d1776423b835012ac316bb0c27cd32bf0e21d82d183260732f0580a547",
+        "dest": "cargo/vendor/egui_demo_lib-0.21.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b46b0a20637084b34122d8f7875cdba0f08b77d270aa23be3fccb5f0a4637174\", \"files\": {}}",
-        "dest": "cargo/vendor/egui-skia-sdl2-event-0.4.0",
+        "contents": "{\"package\": \"86ac92d1776423b835012ac316bb0c27cd32bf0e21d82d183260732f0580a547\", \"files\": {}}",
+        "dest": "cargo/vendor/egui_demo_lib-0.21.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/egui_skia/egui_skia-0.3.0.crate",
-        "sha256": "a9414dfbb8a9fb13ee42e6b18ead56b91fcca01761aba7c4bc049f9d5e720d46",
-        "dest": "cargo/vendor/egui_skia-0.3.0"
+        "url": "https://static.crates.io/crates/egui_extras/egui_extras-0.21.0.crate",
+        "sha256": "8f051342e97dfa2445107cb7d2e720617f5c840199b5cb4fe0ffcf481fcf5cce",
+        "dest": "cargo/vendor/egui_extras-0.21.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a9414dfbb8a9fb13ee42e6b18ead56b91fcca01761aba7c4bc049f9d5e720d46\", \"files\": {}}",
-        "dest": "cargo/vendor/egui_skia-0.3.0",
+        "contents": "{\"package\": \"8f051342e97dfa2445107cb7d2e720617f5c840199b5cb4fe0ffcf481fcf5cce\", \"files\": {}}",
+        "dest": "cargo/vendor/egui_extras-0.21.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "cp -r --reflink=auto \"flatpak-cargo/git/egui_skia.rlib-bad5157/.\" \"cargo/vendor/egui_skia\""
+        ]
+    },
+    {
+        "type": "inline",
+        "contents": "[package]\nname = \"egui_skia\"\nversion = \"0.3.0\"\nedition = \"2021\"\ndescription = \"egui_skia is a skia integration for the egui ui library. Render egui within a skia application or render skia in a egui application.\"\nlicense = \"MIT\"\nhomepage = \"https://github.com/lucasmerlin/egui_skia\"\nrepository = \"https://github.com/lucasmerlin/egui_skia\"\nkeywords = [ \"skia\", \"egui\", \"skia-safe\", \"gui\",]\ncategories = [ \"gui\",]\n\n[features]\nwinit = [ \"dep:egui-winit\",]\ncpu_fix = []\nvulkan = [ \"skia-safe/vulkan\", \"skulpin\",]\nmetal = [ \"skia-safe/metal\",]\n\n[dependencies]\negui_demo_lib = \"=0.21.0\"\nraw-window-handle = \"0.5\"\nforeign-types-shared = \"0.1.1\"\ngl = \"0.14.0\"\n\n[profile.dev]\nopt-level = 3\n\n[dependencies.egui]\ngit = \"https://github.com/MFEK/egui.rlib\"\n\n[dependencies.skia-safe]\nversion = \">= 0.54\"\nfeatures = [ \"gl\",]\n\n[dependencies.egui-winit]\nversion = \">=0.20\"\noptional = true\ndefault-features = false\n\n[dependencies.skulpin]\nversion = \">=0.14.1\"\nfeatures = []\noptional = true\n\n[dependencies.softbuffer]\ngit = \"https://github.com/john01dav/softbuffer\"\n\n[dependencies.sdl2]\nversion = \"0.35.2\"\nfeatures = [ \"raw-window-handle\",]\n\n[dependencies.egui-sdl2-event]\ngit = \"https://github.com/MFEK/egui-sdl2-event.rlib\"\n\n[target.\"cfg(target_os = \\\"macos\\\")\".dev-dependencies]\nmetal = \"0.24\"\ncocoa = \"0.24\"\ncore-graphics-types = \"0.1\"\nobjc = \"0.2\"\n",
+        "dest": "cargo/vendor/egui_skia",
+        "dest-filename": "Cargo.toml"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": null, \"files\": {}}",
+        "dest": "cargo/vendor/egui_skia",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/either/either-1.9.0.crate",
-        "sha256": "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07",
-        "dest": "cargo/vendor/either-1.9.0"
+        "url": "https://static.crates.io/crates/either/either-1.10.0.crate",
+        "sha256": "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a",
+        "dest": "cargo/vendor/either-1.10.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07\", \"files\": {}}",
-        "dest": "cargo/vendor/either-1.9.0",
+        "contents": "{\"package\": \"11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a\", \"files\": {}}",
+        "dest": "cargo/vendor/either-1.10.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/emath/emath-0.22.0.crate",
-        "sha256": "3857d743a6e0741cdd60b622a74c7a36ea75f5f8f11b793b41d905d2c9721a4b",
-        "dest": "cargo/vendor/emath-0.22.0"
+        "url": "https://static.crates.io/crates/emath/emath-0.21.0.crate",
+        "sha256": "b8ecd80612937e0267909d5351770fe150004e24dab93954f69ca62eecd3f77e",
+        "dest": "cargo/vendor/emath-0.21.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3857d743a6e0741cdd60b622a74c7a36ea75f5f8f11b793b41d905d2c9721a4b\", \"files\": {}}",
-        "dest": "cargo/vendor/emath-0.22.0",
+        "contents": "{\"package\": \"b8ecd80612937e0267909d5351770fe150004e24dab93954f69ca62eecd3f77e\", \"files\": {}}",
+        "dest": "cargo/vendor/emath-0.21.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "cp -r --reflink=auto \"flatpak-cargo/git/egui.rlib-307565e/crates/emath\" \"cargo/vendor/emath\""
+        ]
+    },
+    {
+        "type": "inline",
+        "contents": "[package]\nname = \"emath\"\nversion = \"0.22.0\"\nauthors = [ \"Emil Ernerfeldt <emil.ernerfeldt@gmail.com>\",]\ndescription = \"Minimal 2D math library for GUI work\"\nedition = \"2021\"\nrust-version = \"1.65\"\nhomepage = \"https://github.com/emilk/egui/tree/master/crates/emath\"\nlicense = \"MIT OR Apache-2.0\"\nreadme = \"README.md\"\nrepository = \"https://github.com/emilk/egui/tree/master/crates/emath\"\ncategories = [ \"mathematics\", \"gui\",]\nkeywords = [ \"math\", \"gui\",]\ninclude = [ \"../LICENSE-APACHE\", \"../LICENSE-MIT\", \"**/*.rs\", \"Cargo.toml\",]\n\n[lib]\n\n[features]\ndefault = []\nextra_debug_asserts = []\nextra_asserts = []\n\n[dependencies.bytemuck]\nversion = \"1.7.2\"\noptional = true\nfeatures = [ \"derive\",]\n\n[dependencies.document-features]\nversion = \"0.2\"\noptional = true\n\n[dependencies.mint]\nversion = \"0.5.6\"\noptional = true\n\n[dependencies.serde]\nversion = \"1\"\noptional = true\nfeatures = [ \"derive\",]\n\n[package.metadata.docs.rs]\nall-features = true\n",
+        "dest": "cargo/vendor/emath",
+        "dest-filename": "Cargo.toml"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": null, \"files\": {}}",
+        "dest": "cargo/vendor/emath",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1029,6 +1318,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/enum-map/enum-map-2.7.3.crate",
+        "sha256": "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9",
+        "dest": "cargo/vendor/enum-map-2.7.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9\", \"files\": {}}",
+        "dest": "cargo/vendor/enum-map-2.7.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/enum-map-derive/enum-map-derive-0.17.0.crate",
+        "sha256": "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb",
+        "dest": "cargo/vendor/enum-map-derive-0.17.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb\", \"files\": {}}",
+        "dest": "cargo/vendor/enum-map-derive-0.17.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/enum-unitary/enum-unitary-0.4.4.crate",
         "sha256": "fd152dd5adb69db02c4aa7f8d65a9778c2df79dd27367bfadabcbc0dd84c4eca",
         "dest": "cargo/vendor/enum-unitary-0.4.4"
@@ -1055,14 +1370,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/epaint/epaint-0.22.0.crate",
-        "sha256": "09333964d4d57f40a85338ba3ca5ed4716070ab184dcfed966b35491c5c64f3b",
-        "dest": "cargo/vendor/epaint-0.22.0"
+        "url": "https://static.crates.io/crates/epaint/epaint-0.21.0.crate",
+        "sha256": "12e78b5c58a1f7f621f9d546add2adce20636422c9b251e29f749e8a2f713c95",
+        "dest": "cargo/vendor/epaint-0.21.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"09333964d4d57f40a85338ba3ca5ed4716070ab184dcfed966b35491c5c64f3b\", \"files\": {}}",
-        "dest": "cargo/vendor/epaint-0.22.0",
+        "contents": "{\"package\": \"12e78b5c58a1f7f621f9d546add2adce20636422c9b251e29f749e8a2f713c95\", \"files\": {}}",
+        "dest": "cargo/vendor/epaint-0.21.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "cp -r --reflink=auto \"flatpak-cargo/git/egui.rlib-307565e/crates/epaint\" \"cargo/vendor/epaint\""
+        ]
+    },
+    {
+        "type": "inline",
+        "contents": "[[bench]]\nname = \"benchmark\"\nharness = false\n\n[package]\nname = \"epaint\"\nversion = \"0.22.0\"\nauthors = [ \"Emil Ernerfeldt <emil.ernerfeldt@gmail.com>\",]\ndescription = \"Minimal 2D graphics library for GUI work\"\nedition = \"2021\"\nrust-version = \"1.65\"\nhomepage = \"https://github.com/emilk/egui/tree/master/crates/epaint\"\nlicense = \"(MIT OR Apache-2.0) AND OFL-1.1 AND LicenseRef-UFL-1.0\"\nreadme = \"README.md\"\nrepository = \"https://github.com/emilk/egui/tree/master/crates/epaint\"\ncategories = [ \"graphics\", \"gui\",]\nkeywords = [ \"graphics\", \"gui\", \"egui\",]\ninclude = [ \"../LICENSE-APACHE\", \"../LICENSE-MIT\", \"**/*.rs\", \"Cargo.toml\", \"fonts/*.ttf\", \"fonts/*.txt\", \"fonts/OFL.txt\", \"fonts/UFL.txt\",]\n\n[lib]\n\n[features]\ndefault = [ \"default_fonts\",]\nbytemuck = [ \"dep:bytemuck\", \"emath/bytemuck\", \"ecolor/bytemuck\",]\ncint = [ \"ecolor/cint\",]\ncolor-hex = [ \"ecolor/color-hex\",]\ndeadlock_detection = [ \"dep:backtrace\",]\ndefault_fonts = []\nextra_debug_asserts = [ \"emath/extra_debug_asserts\", \"ecolor/extra_debug_asserts\",]\nextra_asserts = [ \"emath/extra_asserts\", \"ecolor/extra_asserts\",]\nlog = [ \"dep:log\",]\nmint = [ \"emath/mint\",]\nserde = [ \"dep:serde\", \"ahash/serde\", \"emath/serde\", \"ecolor/serde\",]\nunity = []\n\n[dependencies]\nab_glyph = \"0.2.11\"\nnohash-hasher = \"0.2\"\n\n[dependencies.emath]\nversion = \"0.22.0\"\npath = \"../emath\"\n\n[dependencies.ecolor]\nversion = \"0.22.0\"\npath = \"../ecolor\"\n\n[dependencies.ahash]\nversion = \"0.8.1\"\ndefault-features = false\nfeatures = [ \"no-rng\", \"std\",]\n\n[dependencies.bytemuck]\nversion = \"1.7.2\"\noptional = true\nfeatures = [ \"derive\",]\n\n[dependencies.document-features]\nversion = \"0.2\"\noptional = true\n\n[dependencies.log]\nversion = \"0.4\"\noptional = true\nfeatures = [ \"std\",]\n\n[dependencies.serde]\nversion = \"1\"\noptional = true\nfeatures = [ \"derive\", \"rc\",]\n\n[dev-dependencies.criterion]\nversion = \"0.4\"\ndefault-features = false\n\n[target.\"cfg(not(target_arch = \\\"wasm32\\\"))\".dependencies]\nparking_lot = \"0.12\"\n\n[target.\"cfg(target_arch = \\\"wasm32\\\")\".dependencies]\natomic_refcell = \"0.1\"\n\n[package.metadata.docs.rs]\nall-features = true\n\n[target.\"cfg(not(target_arch = \\\"wasm32\\\"))\".dependencies.backtrace]\nversion = \"0.3\"\noptional = true\n",
+        "dest": "cargo/vendor/epaint",
+        "dest-filename": "Cargo.toml"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": null, \"files\": {}}",
+        "dest": "cargo/vendor/epaint",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1081,27 +1414,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/errno/errno-0.3.3.crate",
-        "sha256": "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd",
-        "dest": "cargo/vendor/errno-0.3.3"
+        "url": "https://static.crates.io/crates/errno/errno-0.3.8.crate",
+        "sha256": "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245",
+        "dest": "cargo/vendor/errno-0.3.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd\", \"files\": {}}",
-        "dest": "cargo/vendor/errno-0.3.3",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/errno-dragonfly/errno-dragonfly-0.1.2.crate",
-        "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
-        "dest": "cargo/vendor/errno-dragonfly-0.1.2"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf\", \"files\": {}}",
-        "dest": "cargo/vendor/errno-dragonfly-0.1.2",
+        "contents": "{\"package\": \"a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245\", \"files\": {}}",
+        "dest": "cargo/vendor/errno-0.3.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1133,14 +1453,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fdeflate/fdeflate-0.3.0.crate",
-        "sha256": "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10",
-        "dest": "cargo/vendor/fdeflate-0.3.0"
+        "url": "https://static.crates.io/crates/fastrand/fastrand-2.0.2.crate",
+        "sha256": "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984",
+        "dest": "cargo/vendor/fastrand-2.0.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10\", \"files\": {}}",
-        "dest": "cargo/vendor/fdeflate-0.3.0",
+        "contents": "{\"package\": \"658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984\", \"files\": {}}",
+        "dest": "cargo/vendor/fastrand-2.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fdeflate/fdeflate-0.3.4.crate",
+        "sha256": "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645",
+        "dest": "cargo/vendor/fdeflate-0.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645\", \"files\": {}}",
+        "dest": "cargo/vendor/fdeflate-0.3.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1159,27 +1492,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/filetime/filetime-0.2.22.crate",
-        "sha256": "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0",
-        "dest": "cargo/vendor/filetime-0.2.22"
+        "url": "https://static.crates.io/crates/filetime/filetime-0.2.23.crate",
+        "sha256": "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd",
+        "dest": "cargo/vendor/filetime-0.2.23"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0\", \"files\": {}}",
-        "dest": "cargo/vendor/filetime-0.2.22",
+        "contents": "{\"package\": \"1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd\", \"files\": {}}",
+        "dest": "cargo/vendor/filetime-0.2.23",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/flate2/flate2-1.0.27.crate",
-        "sha256": "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010",
-        "dest": "cargo/vendor/flate2-1.0.27"
+        "url": "https://static.crates.io/crates/flate2/flate2-1.0.28.crate",
+        "sha256": "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e",
+        "dest": "cargo/vendor/flate2-1.0.28"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010\", \"files\": {}}",
-        "dest": "cargo/vendor/flate2-1.0.27",
+        "contents": "{\"package\": \"46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e\", \"files\": {}}",
+        "dest": "cargo/vendor/flate2-1.0.28",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1250,6 +1583,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types/foreign-types-0.5.0.crate",
+        "sha256": "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965",
+        "dest": "cargo/vendor/foreign-types-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types-macros/foreign-types-macros-0.2.3.crate",
+        "sha256": "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742",
+        "dest": "cargo/vendor/foreign-types-macros-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-macros-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/foreign-types-shared/foreign-types-shared-0.1.1.crate",
         "sha256": "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b",
         "dest": "cargo/vendor/foreign-types-shared-0.1.1"
@@ -1263,14 +1622,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/form_urlencoded/form_urlencoded-1.2.0.crate",
-        "sha256": "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652",
-        "dest": "cargo/vendor/form_urlencoded-1.2.0"
+        "url": "https://static.crates.io/crates/foreign-types-shared/foreign-types-shared-0.3.1.crate",
+        "sha256": "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b",
+        "dest": "cargo/vendor/foreign-types-shared-0.3.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652\", \"files\": {}}",
-        "dest": "cargo/vendor/form_urlencoded-1.2.0",
+        "contents": "{\"package\": \"aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-shared-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1328,118 +1687,118 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures/futures-0.3.28.crate",
-        "sha256": "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40",
-        "dest": "cargo/vendor/futures-0.3.28"
+        "url": "https://static.crates.io/crates/futures/futures-0.3.30.crate",
+        "sha256": "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0",
+        "dest": "cargo/vendor/futures-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-0.3.28",
+        "contents": "{\"package\": \"645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.28.crate",
-        "sha256": "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2",
-        "dest": "cargo/vendor/futures-channel-0.3.28"
+        "url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.30.crate",
+        "sha256": "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78",
+        "dest": "cargo/vendor/futures-channel-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-channel-0.3.28",
+        "contents": "{\"package\": \"eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-channel-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-core/futures-core-0.3.28.crate",
-        "sha256": "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c",
-        "dest": "cargo/vendor/futures-core-0.3.28"
+        "url": "https://static.crates.io/crates/futures-core/futures-core-0.3.30.crate",
+        "sha256": "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d",
+        "dest": "cargo/vendor/futures-core-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-core-0.3.28",
+        "contents": "{\"package\": \"dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-core-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-executor/futures-executor-0.3.28.crate",
-        "sha256": "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0",
-        "dest": "cargo/vendor/futures-executor-0.3.28"
+        "url": "https://static.crates.io/crates/futures-executor/futures-executor-0.3.30.crate",
+        "sha256": "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d",
+        "dest": "cargo/vendor/futures-executor-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-executor-0.3.28",
+        "contents": "{\"package\": \"a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-executor-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-io/futures-io-0.3.28.crate",
-        "sha256": "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964",
-        "dest": "cargo/vendor/futures-io-0.3.28"
+        "url": "https://static.crates.io/crates/futures-io/futures-io-0.3.30.crate",
+        "sha256": "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1",
+        "dest": "cargo/vendor/futures-io-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-io-0.3.28",
+        "contents": "{\"package\": \"a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-io-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-macro/futures-macro-0.3.28.crate",
-        "sha256": "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72",
-        "dest": "cargo/vendor/futures-macro-0.3.28"
+        "url": "https://static.crates.io/crates/futures-macro/futures-macro-0.3.30.crate",
+        "sha256": "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac",
+        "dest": "cargo/vendor/futures-macro-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-macro-0.3.28",
+        "contents": "{\"package\": \"87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-macro-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-sink/futures-sink-0.3.28.crate",
-        "sha256": "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e",
-        "dest": "cargo/vendor/futures-sink-0.3.28"
+        "url": "https://static.crates.io/crates/futures-sink/futures-sink-0.3.30.crate",
+        "sha256": "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5",
+        "dest": "cargo/vendor/futures-sink-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-sink-0.3.28",
+        "contents": "{\"package\": \"9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-sink-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-task/futures-task-0.3.28.crate",
-        "sha256": "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65",
-        "dest": "cargo/vendor/futures-task-0.3.28"
+        "url": "https://static.crates.io/crates/futures-task/futures-task-0.3.30.crate",
+        "sha256": "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004",
+        "dest": "cargo/vendor/futures-task-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-task-0.3.28",
+        "contents": "{\"package\": \"38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-task-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-util/futures-util-0.3.28.crate",
-        "sha256": "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533",
-        "dest": "cargo/vendor/futures-util-0.3.28"
+        "url": "https://static.crates.io/crates/futures-util/futures-util-0.3.30.crate",
+        "sha256": "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48",
+        "dest": "cargo/vendor/futures-util-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-util-0.3.28",
+        "contents": "{\"package\": \"3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-util-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1510,27 +1869,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/getrandom/getrandom-0.2.10.crate",
-        "sha256": "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427",
-        "dest": "cargo/vendor/getrandom-0.2.10"
+        "url": "https://static.crates.io/crates/gethostname/gethostname-0.4.3.crate",
+        "sha256": "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818",
+        "dest": "cargo/vendor/gethostname-0.4.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427\", \"files\": {}}",
-        "dest": "cargo/vendor/getrandom-0.2.10",
+        "contents": "{\"package\": \"0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818\", \"files\": {}}",
+        "dest": "cargo/vendor/gethostname-0.4.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gimli/gimli-0.28.0.crate",
-        "sha256": "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0",
-        "dest": "cargo/vendor/gimli-0.28.0"
+        "url": "https://static.crates.io/crates/getrandom/getrandom-0.2.12.crate",
+        "sha256": "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5",
+        "dest": "cargo/vendor/getrandom-0.2.12"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0\", \"files\": {}}",
-        "dest": "cargo/vendor/gimli-0.28.0",
+        "contents": "{\"package\": \"190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5\", \"files\": {}}",
+        "dest": "cargo/vendor/getrandom-0.2.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gimli/gimli-0.28.1.crate",
+        "sha256": "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253",
+        "dest": "cargo/vendor/gimli-0.28.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253\", \"files\": {}}",
+        "dest": "cargo/vendor/gimli-0.28.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1562,27 +1934,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/git-version/git-version-0.3.5.crate",
-        "sha256": "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899",
-        "dest": "cargo/vendor/git-version-0.3.5"
+        "url": "https://static.crates.io/crates/git-version/git-version-0.3.9.crate",
+        "sha256": "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19",
+        "dest": "cargo/vendor/git-version-0.3.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899\", \"files\": {}}",
-        "dest": "cargo/vendor/git-version-0.3.5",
+        "contents": "{\"package\": \"1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19\", \"files\": {}}",
+        "dest": "cargo/vendor/git-version-0.3.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/git-version-macro/git-version-macro-0.3.5.crate",
-        "sha256": "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f",
-        "dest": "cargo/vendor/git-version-macro-0.3.5"
+        "url": "https://static.crates.io/crates/git-version-macro/git-version-macro-0.3.9.crate",
+        "sha256": "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0",
+        "dest": "cargo/vendor/git-version-macro-0.3.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f\", \"files\": {}}",
-        "dest": "cargo/vendor/git-version-macro-0.3.5",
+        "contents": "{\"package\": \"53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0\", \"files\": {}}",
+        "dest": "cargo/vendor/git-version-macro-0.3.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1653,7 +2025,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/glifparser.rlib-f8dcacb/.\" \"cargo/vendor/glifparser\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/glifparser.rlib-c642cc8/.\" \"cargo/vendor/glifparser\""
         ]
     },
     {
@@ -1671,12 +2043,12 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/glifrenderer.rlib-044324a/.\" \"cargo/vendor/glifrenderer\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/glifrenderer.rlib-7fd9b9e/.\" \"cargo/vendor/glifrenderer\""
         ]
     },
     {
         "type": "inline",
-        "contents": "[package]\nname = \"glifrenderer\"\nversion = \"0.1.2\"\nedition = \"2021\"\n\n[dependencies]\nskia-safe = \">0.53.0\"\nlog = \"0.4\"\nfont-kit = \"0.10\"\nderive_more = \"0.99\"\nenum-unitary = \"0.4.3\"\nenum-iterator = \"0.7.0\"\nlazy_static = \"1.4\"\nkurbo = \"0.8\"\nflo_curves = \"0.6\"\nnum-traits = \"0.2\"\n\n[dependencies.glifparser]\ngit = \"https://github.com/MFEK/glifparser.rlib\"\nbranch = \"master\"\nfeatures = [ \"mfek\", \"skia\",]\n\n[dependencies.MFEKmath]\ngit = \"https://github.com/MFEK/math.rlib\"\nbranch = \"main\"\nfeatures = [ \"skia\",]\n",
+        "contents": "[package]\nname = \"glifrenderer\"\nversion = \"0.1.2\"\nedition = \"2021\"\n\n[dependencies]\nskia-safe = \">=0.54.0\"\nlog = \"0.4\"\nfont-kit = \"0.10\"\nderive_more = \"0.99\"\nenum-unitary = \"0.4.3\"\nenum-iterator = \"0.7.0\"\nlazy_static = \"1.4\"\nkurbo = \"0.8\"\nflo_curves = \"0.6\"\nnum-traits = \"0.2\"\n\n[dependencies.glifparser]\ngit = \"https://github.com/MFEK/glifparser.rlib\"\nbranch = \"master\"\nfeatures = [ \"mfek\", \"skia\",]\n\n[dependencies.MFEKmath]\ngit = \"https://github.com/MFEK/math.rlib\"\nbranch = \"main\"\nfeatures = [ \"skia\",]\n",
         "dest": "cargo/vendor/glifrenderer",
         "dest-filename": "Cargo.toml"
     },
@@ -1754,14 +2126,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.14.2.crate",
-        "sha256": "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156",
-        "dest": "cargo/vendor/hashbrown-0.14.2"
+        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.14.3.crate",
+        "sha256": "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604",
+        "dest": "cargo/vendor/hashbrown-0.14.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156\", \"files\": {}}",
-        "dest": "cargo/vendor/hashbrown-0.14.2",
+        "contents": "{\"package\": \"290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604\", \"files\": {}}",
+        "dest": "cargo/vendor/hashbrown-0.14.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1806,14 +2178,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/hermit-abi/hermit-abi-0.3.2.crate",
-        "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b",
-        "dest": "cargo/vendor/hermit-abi-0.3.2"
+        "url": "https://static.crates.io/crates/home/home-0.5.9.crate",
+        "sha256": "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5",
+        "dest": "cargo/vendor/home-0.5.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b\", \"files\": {}}",
-        "dest": "cargo/vendor/hermit-abi-0.3.2",
+        "contents": "{\"package\": \"e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5\", \"files\": {}}",
+        "dest": "cargo/vendor/home-0.5.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1832,14 +2204,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/iana-time-zone/iana-time-zone-0.1.57.crate",
-        "sha256": "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613",
-        "dest": "cargo/vendor/iana-time-zone-0.1.57"
+        "url": "https://static.crates.io/crates/iana-time-zone/iana-time-zone-0.1.60.crate",
+        "sha256": "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141",
+        "dest": "cargo/vendor/iana-time-zone-0.1.60"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613\", \"files\": {}}",
-        "dest": "cargo/vendor/iana-time-zone-0.1.57",
+        "contents": "{\"package\": \"e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141\", \"files\": {}}",
+        "dest": "cargo/vendor/iana-time-zone-0.1.60",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1858,19 +2230,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/idna/idna-0.4.0.crate",
-        "sha256": "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c",
-        "dest": "cargo/vendor/idna-0.4.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c\", \"files\": {}}",
-        "dest": "cargo/vendor/idna-0.4.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/image/image-0.23.14.crate",
         "sha256": "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1",
         "dest": "cargo/vendor/image-0.23.14"
@@ -1884,14 +2243,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/image/image-0.24.7.crate",
-        "sha256": "6f3dfdbdd72063086ff443e297b61695500514b1e41095b6fb9a5ab48a70a711",
-        "dest": "cargo/vendor/image-0.24.7"
+        "url": "https://static.crates.io/crates/image/image-0.24.9.crate",
+        "sha256": "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d",
+        "dest": "cargo/vendor/image-0.24.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6f3dfdbdd72063086ff443e297b61695500514b1e41095b6fb9a5ab48a70a711\", \"files\": {}}",
-        "dest": "cargo/vendor/image-0.24.7",
+        "contents": "{\"package\": \"5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d\", \"files\": {}}",
+        "dest": "cargo/vendor/image-0.24.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1910,14 +2269,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/indexmap/indexmap-2.1.0.crate",
-        "sha256": "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f",
-        "dest": "cargo/vendor/indexmap-2.1.0"
+        "url": "https://static.crates.io/crates/indexmap/indexmap-2.2.6.crate",
+        "sha256": "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26",
+        "dest": "cargo/vendor/indexmap-2.2.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f\", \"files\": {}}",
-        "dest": "cargo/vendor/indexmap-2.1.0",
+        "contents": "{\"package\": \"168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26\", \"files\": {}}",
+        "dest": "cargo/vendor/indexmap-2.2.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1975,19 +2334,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/is-terminal/is-terminal-0.4.9.crate",
-        "sha256": "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b",
-        "dest": "cargo/vendor/is-terminal-0.4.9"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b\", \"files\": {}}",
-        "dest": "cargo/vendor/is-terminal-0.4.9",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/itertools/itertools-0.8.2.crate",
         "sha256": "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484",
         "dest": "cargo/vendor/itertools-0.8.2"
@@ -2027,14 +2373,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/itoa/itoa-1.0.9.crate",
-        "sha256": "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38",
-        "dest": "cargo/vendor/itoa-1.0.9"
+        "url": "https://static.crates.io/crates/itertools/itertools-0.12.1.crate",
+        "sha256": "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569",
+        "dest": "cargo/vendor/itertools-0.12.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38\", \"files\": {}}",
-        "dest": "cargo/vendor/itoa-1.0.9",
+        "contents": "{\"package\": \"ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569\", \"files\": {}}",
+        "dest": "cargo/vendor/itertools-0.12.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/itoa/itoa-1.0.11.crate",
+        "sha256": "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b",
+        "dest": "cargo/vendor/itoa-1.0.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b\", \"files\": {}}",
+        "dest": "cargo/vendor/itoa-1.0.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2053,14 +2412,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.64.crate",
-        "sha256": "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a",
-        "dest": "cargo/vendor/js-sys-0.3.64"
+        "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.69.crate",
+        "sha256": "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d",
+        "dest": "cargo/vendor/js-sys-0.3.69"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a\", \"files\": {}}",
-        "dest": "cargo/vendor/js-sys-0.3.64",
+        "contents": "{\"package\": \"29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d\", \"files\": {}}",
+        "dest": "cargo/vendor/js-sys-0.3.69",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2162,79 +2521,105 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libc/libc-0.2.147.crate",
-        "sha256": "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3",
-        "dest": "cargo/vendor/libc-0.2.147"
+        "url": "https://static.crates.io/crates/libc/libc-0.2.153.crate",
+        "sha256": "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd",
+        "dest": "cargo/vendor/libc-0.2.153"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3\", \"files\": {}}",
-        "dest": "cargo/vendor/libc-0.2.147",
+        "contents": "{\"package\": \"9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd\", \"files\": {}}",
+        "dest": "cargo/vendor/libc-0.2.153",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libloading/libloading-0.7.4.crate",
-        "sha256": "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f",
-        "dest": "cargo/vendor/libloading-0.7.4"
+        "url": "https://static.crates.io/crates/libloading/libloading-0.8.3.crate",
+        "sha256": "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19",
+        "dest": "cargo/vendor/libloading-0.8.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f\", \"files\": {}}",
-        "dest": "cargo/vendor/libloading-0.7.4",
+        "contents": "{\"package\": \"0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19\", \"files\": {}}",
+        "dest": "cargo/vendor/libloading-0.8.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/line-wrap/line-wrap-0.1.1.crate",
-        "sha256": "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9",
-        "dest": "cargo/vendor/line-wrap-0.1.1"
+        "url": "https://static.crates.io/crates/libredox/libredox-0.0.1.crate",
+        "sha256": "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8",
+        "dest": "cargo/vendor/libredox-0.0.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9\", \"files\": {}}",
-        "dest": "cargo/vendor/line-wrap-0.1.1",
+        "contents": "{\"package\": \"85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8\", \"files\": {}}",
+        "dest": "cargo/vendor/libredox-0.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.4.5.crate",
-        "sha256": "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503",
-        "dest": "cargo/vendor/linux-raw-sys-0.4.5"
+        "url": "https://static.crates.io/crates/line-wrap/line-wrap-0.2.0.crate",
+        "sha256": "dd1bc4d24ad230d21fb898d1116b1801d7adfc449d42026475862ab48b11e70e",
+        "dest": "cargo/vendor/line-wrap-0.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503\", \"files\": {}}",
-        "dest": "cargo/vendor/linux-raw-sys-0.4.5",
+        "contents": "{\"package\": \"dd1bc4d24ad230d21fb898d1116b1801d7adfc449d42026475862ab48b11e70e\", \"files\": {}}",
+        "dest": "cargo/vendor/line-wrap-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/lock_api/lock_api-0.4.10.crate",
-        "sha256": "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16",
-        "dest": "cargo/vendor/lock_api-0.4.10"
+        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.4.13.crate",
+        "sha256": "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c",
+        "dest": "cargo/vendor/linux-raw-sys-0.4.13"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16\", \"files\": {}}",
-        "dest": "cargo/vendor/lock_api-0.4.10",
+        "contents": "{\"package\": \"01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c\", \"files\": {}}",
+        "dest": "cargo/vendor/linux-raw-sys-0.4.13",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/log/log-0.4.20.crate",
-        "sha256": "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f",
-        "dest": "cargo/vendor/log-0.4.20"
+        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.6.4.crate",
+        "sha256": "f0b5399f6804fbab912acbd8878ed3532d506b7c951b8f9f164ef90fef39e3f4",
+        "dest": "cargo/vendor/linux-raw-sys-0.6.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f\", \"files\": {}}",
-        "dest": "cargo/vendor/log-0.4.20",
+        "contents": "{\"package\": \"f0b5399f6804fbab912acbd8878ed3532d506b7c951b8f9f164ef90fef39e3f4\", \"files\": {}}",
+        "dest": "cargo/vendor/linux-raw-sys-0.6.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lock_api/lock_api-0.4.11.crate",
+        "sha256": "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45",
+        "dest": "cargo/vendor/lock_api-0.4.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45\", \"files\": {}}",
+        "dest": "cargo/vendor/lock_api-0.4.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/log/log-0.4.21.crate",
+        "sha256": "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c",
+        "dest": "cargo/vendor/log-0.4.21"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c\", \"files\": {}}",
+        "dest": "cargo/vendor/log-0.4.21",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2253,14 +2638,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/memchr/memchr-2.6.2.crate",
-        "sha256": "5486aed0026218e61b8a01d5fbd5a0a134649abb71a0e53b7bc088529dced86e",
-        "dest": "cargo/vendor/memchr-2.6.2"
+        "url": "https://static.crates.io/crates/memchr/memchr-2.7.1.crate",
+        "sha256": "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149",
+        "dest": "cargo/vendor/memchr-2.7.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5486aed0026218e61b8a01d5fbd5a0a134649abb71a0e53b7bc088529dced86e\", \"files\": {}}",
-        "dest": "cargo/vendor/memchr-2.6.2",
+        "contents": "{\"package\": \"523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149\", \"files\": {}}",
+        "dest": "cargo/vendor/memchr-2.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/memmap2/memmap2-0.9.4.crate",
+        "sha256": "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322",
+        "dest": "cargo/vendor/memmap2-0.9.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322\", \"files\": {}}",
+        "dest": "cargo/vendor/memmap2-0.9.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2336,27 +2734,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.7.1.crate",
-        "sha256": "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7",
-        "dest": "cargo/vendor/miniz_oxide-0.7.1"
+        "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.7.2.crate",
+        "sha256": "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7",
+        "dest": "cargo/vendor/miniz_oxide-0.7.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7\", \"files\": {}}",
-        "dest": "cargo/vendor/miniz_oxide-0.7.1",
+        "contents": "{\"package\": \"9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7\", \"files\": {}}",
+        "dest": "cargo/vendor/miniz_oxide-0.7.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/mio/mio-0.8.8.crate",
-        "sha256": "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2",
-        "dest": "cargo/vendor/mio-0.8.8"
+        "url": "https://static.crates.io/crates/mio/mio-0.8.11.crate",
+        "sha256": "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c",
+        "dest": "cargo/vendor/mio-0.8.11"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2\", \"files\": {}}",
-        "dest": "cargo/vendor/mio-0.8.8",
+        "contents": "{\"package\": \"a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c\", \"files\": {}}",
+        "dest": "cargo/vendor/mio-0.8.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2406,14 +2804,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/nix/nix-0.26.4.crate",
-        "sha256": "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b",
-        "dest": "cargo/vendor/nix-0.26.4"
+        "url": "https://static.crates.io/crates/nix/nix-0.28.0.crate",
+        "sha256": "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4",
+        "dest": "cargo/vendor/nix-0.28.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b\", \"files\": {}}",
-        "dest": "cargo/vendor/nix-0.26.4",
+        "contents": "{\"package\": \"ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4\", \"files\": {}}",
+        "dest": "cargo/vendor/nix-0.28.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2484,14 +2882,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/num-complex/num-complex-0.4.4.crate",
-        "sha256": "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214",
-        "dest": "cargo/vendor/num-complex-0.4.4"
+        "url": "https://static.crates.io/crates/num-complex/num-complex-0.4.5.crate",
+        "sha256": "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6",
+        "dest": "cargo/vendor/num-complex-0.4.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214\", \"files\": {}}",
-        "dest": "cargo/vendor/num-complex-0.4.4",
+        "contents": "{\"package\": \"23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6\", \"files\": {}}",
+        "dest": "cargo/vendor/num-complex-0.4.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-conv/num-conv-0.1.0.crate",
+        "sha256": "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9",
+        "dest": "cargo/vendor/num-conv-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9\", \"files\": {}}",
+        "dest": "cargo/vendor/num-conv-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2510,27 +2921,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/num-integer/num-integer-0.1.45.crate",
-        "sha256": "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9",
-        "dest": "cargo/vendor/num-integer-0.1.45"
+        "url": "https://static.crates.io/crates/num-integer/num-integer-0.1.46.crate",
+        "sha256": "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f",
+        "dest": "cargo/vendor/num-integer-0.1.46"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9\", \"files\": {}}",
-        "dest": "cargo/vendor/num-integer-0.1.45",
+        "contents": "{\"package\": \"7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f\", \"files\": {}}",
+        "dest": "cargo/vendor/num-integer-0.1.46",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/num-iter/num-iter-0.1.43.crate",
-        "sha256": "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252",
-        "dest": "cargo/vendor/num-iter-0.1.43"
+        "url": "https://static.crates.io/crates/num-iter/num-iter-0.1.44.crate",
+        "sha256": "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9",
+        "dest": "cargo/vendor/num-iter-0.1.44"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252\", \"files\": {}}",
-        "dest": "cargo/vendor/num-iter-0.1.43",
+        "contents": "{\"package\": \"d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9\", \"files\": {}}",
+        "dest": "cargo/vendor/num-iter-0.1.44",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2562,14 +2973,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/num-traits/num-traits-0.2.16.crate",
-        "sha256": "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2",
-        "dest": "cargo/vendor/num-traits-0.2.16"
+        "url": "https://static.crates.io/crates/num-traits/num-traits-0.2.18.crate",
+        "sha256": "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a",
+        "dest": "cargo/vendor/num-traits-0.2.18"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2\", \"files\": {}}",
-        "dest": "cargo/vendor/num-traits-0.2.16",
+        "contents": "{\"package\": \"da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a\", \"files\": {}}",
+        "dest": "cargo/vendor/num-traits-0.2.18",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2614,53 +3025,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/object/object-0.32.0.crate",
-        "sha256": "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe",
-        "dest": "cargo/vendor/object-0.32.0"
+        "url": "https://static.crates.io/crates/object/object-0.32.2.crate",
+        "sha256": "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441",
+        "dest": "cargo/vendor/object-0.32.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe\", \"files\": {}}",
-        "dest": "cargo/vendor/object-0.32.0",
+        "contents": "{\"package\": \"a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441\", \"files\": {}}",
+        "dest": "cargo/vendor/object-0.32.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/once_cell/once_cell-1.18.0.crate",
-        "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
-        "dest": "cargo/vendor/once_cell-1.18.0"
+        "url": "https://static.crates.io/crates/once_cell/once_cell-1.19.0.crate",
+        "sha256": "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92",
+        "dest": "cargo/vendor/once_cell-1.19.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d\", \"files\": {}}",
-        "dest": "cargo/vendor/once_cell-1.18.0",
+        "contents": "{\"package\": \"3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92\", \"files\": {}}",
+        "dest": "cargo/vendor/once_cell-1.19.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/os_str_bytes/os_str_bytes-6.5.1.crate",
-        "sha256": "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac",
-        "dest": "cargo/vendor/os_str_bytes-6.5.1"
+        "url": "https://static.crates.io/crates/os_str_bytes/os_str_bytes-6.6.1.crate",
+        "sha256": "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1",
+        "dest": "cargo/vendor/os_str_bytes-6.6.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac\", \"files\": {}}",
-        "dest": "cargo/vendor/os_str_bytes-6.5.1",
+        "contents": "{\"package\": \"e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1\", \"files\": {}}",
+        "dest": "cargo/vendor/os_str_bytes-6.6.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/owned_ttf_parser/owned_ttf_parser-0.19.0.crate",
-        "sha256": "706de7e2214113d63a8238d1910463cfce781129a6f263d13fdb09ff64355ba4",
-        "dest": "cargo/vendor/owned_ttf_parser-0.19.0"
+        "url": "https://static.crates.io/crates/owned_ttf_parser/owned_ttf_parser-0.20.0.crate",
+        "sha256": "d4586edfe4c648c71797a74c84bacb32b52b212eff5dfe2bb9f2c599844023e7",
+        "dest": "cargo/vendor/owned_ttf_parser-0.20.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"706de7e2214113d63a8238d1910463cfce781129a6f263d13fdb09ff64355ba4\", \"files\": {}}",
-        "dest": "cargo/vendor/owned_ttf_parser-0.19.0",
+        "contents": "{\"package\": \"d4586edfe4c648c71797a74c84bacb32b52b212eff5dfe2bb9f2c599844023e7\", \"files\": {}}",
+        "dest": "cargo/vendor/owned_ttf_parser-0.20.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2705,14 +3116,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.9.8.crate",
-        "sha256": "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447",
-        "dest": "cargo/vendor/parking_lot_core-0.9.8"
+        "url": "https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.9.9.crate",
+        "sha256": "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e",
+        "dest": "cargo/vendor/parking_lot_core-0.9.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447\", \"files\": {}}",
-        "dest": "cargo/vendor/parking_lot_core-0.9.8",
+        "contents": "{\"package\": \"4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e\", \"files\": {}}",
+        "dest": "cargo/vendor/parking_lot_core-0.9.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2729,55 +3140,21 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pathfinder_simd/pathfinder_simd-0.5.1.crate",
-        "sha256": "39fe46acc5503595e5949c17b818714d26fdf9b4920eacf3b2947f0199f4a6ff",
-        "dest": "cargo/vendor/pathfinder_simd-0.5.1"
+        "type": "shell",
+        "commands": [
+            "cp -r --reflink=auto \"flatpak-cargo/git/pathfinder-30419d0/simd\" \"cargo/vendor/pathfinder_simd\""
+        ]
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"39fe46acc5503595e5949c17b818714d26fdf9b4920eacf3b2947f0199f4a6ff\", \"files\": {}}",
-        "dest": "cargo/vendor/pathfinder_simd-0.5.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/peeking_take_while/peeking_take_while-0.1.2.crate",
-        "sha256": "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099",
-        "dest": "cargo/vendor/peeking_take_while-0.1.2"
+        "contents": "[package]\nname = \"pathfinder_simd\"\nversion = \"0.5.3\"\nedition = \"2018\"\nauthors = [ \"Patrick Walton <pcwalton@mimiga.net>\",]\nbuild = \"build.rs\"\ndescription = \"A simple SIMD library\"\nlicense = \"MIT OR Apache-2.0\"\nrepository = \"https://github.com/servo/pathfinder\"\nhomepage = \"https://github.com/servo/pathfinder\"\n\n[features]\npf-no-simd = []\n\n[dependencies]\n\n[build-dependencies]\nrustc_version = \"0.4\"\n",
+        "dest": "cargo/vendor/pathfinder_simd",
+        "dest-filename": "Cargo.toml"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099\", \"files\": {}}",
-        "dest": "cargo/vendor/peeking_take_while-0.1.2",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/percent-encoding/percent-encoding-2.3.0.crate",
-        "sha256": "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94",
-        "dest": "cargo/vendor/percent-encoding-2.3.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94\", \"files\": {}}",
-        "dest": "cargo/vendor/percent-encoding-2.3.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pest/pest-2.7.3.crate",
-        "sha256": "d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33",
-        "dest": "cargo/vendor/pest-2.7.3"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33\", \"files\": {}}",
-        "dest": "cargo/vendor/pest-2.7.3",
+        "contents": "{\"package\": null, \"files\": {}}",
+        "dest": "cargo/vendor/pathfinder_simd",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2809,27 +3186,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pkg-config/pkg-config-0.3.27.crate",
-        "sha256": "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964",
-        "dest": "cargo/vendor/pkg-config-0.3.27"
+        "url": "https://static.crates.io/crates/pkg-config/pkg-config-0.3.30.crate",
+        "sha256": "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec",
+        "dest": "cargo/vendor/pkg-config-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964\", \"files\": {}}",
-        "dest": "cargo/vendor/pkg-config-0.3.27",
+        "contents": "{\"package\": \"d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec\", \"files\": {}}",
+        "dest": "cargo/vendor/pkg-config-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/plist/plist-1.5.0.crate",
-        "sha256": "bdc0001cfea3db57a2e24bc0d818e9e20e554b5f97fabb9bc231dc240269ae06",
-        "dest": "cargo/vendor/plist-1.5.0"
+        "url": "https://static.crates.io/crates/plist/plist-1.6.1.crate",
+        "sha256": "d9d34169e64b3c7a80c8621a48adaf44e0cf62c78a9b25dd9dd35f1881a17cf9",
+        "dest": "cargo/vendor/plist-1.6.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bdc0001cfea3db57a2e24bc0d818e9e20e554b5f97fabb9bc231dc240269ae06\", \"files\": {}}",
-        "dest": "cargo/vendor/plist-1.5.0",
+        "contents": "{\"package\": \"d9d34169e64b3c7a80c8621a48adaf44e0cf62c78a9b25dd9dd35f1881a17cf9\", \"files\": {}}",
+        "dest": "cargo/vendor/plist-1.6.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2848,27 +3225,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/png/png-0.17.10.crate",
-        "sha256": "dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64",
-        "dest": "cargo/vendor/png-0.17.10"
+        "url": "https://static.crates.io/crates/png/png-0.17.13.crate",
+        "sha256": "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1",
+        "dest": "cargo/vendor/png-0.17.13"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64\", \"files\": {}}",
-        "dest": "cargo/vendor/png-0.17.10",
+        "contents": "{\"package\": \"06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1\", \"files\": {}}",
+        "dest": "cargo/vendor/png-0.17.13",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/prettyplease/prettyplease-0.2.15.crate",
-        "sha256": "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d",
-        "dest": "cargo/vendor/prettyplease-0.2.15"
+        "url": "https://static.crates.io/crates/powerfmt/powerfmt-0.2.0.crate",
+        "sha256": "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391",
+        "dest": "cargo/vendor/powerfmt-0.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d\", \"files\": {}}",
-        "dest": "cargo/vendor/prettyplease-0.2.15",
+        "contents": "{\"package\": \"439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391\", \"files\": {}}",
+        "dest": "cargo/vendor/powerfmt-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/prettyplease/prettyplease-0.2.17.crate",
+        "sha256": "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7",
+        "dest": "cargo/vendor/prettyplease-0.2.17"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7\", \"files\": {}}",
+        "dest": "cargo/vendor/prettyplease-0.2.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2913,27 +3303,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/proc-macro-hack/proc-macro-hack-0.5.20+deprecated.crate",
-        "sha256": "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068",
-        "dest": "cargo/vendor/proc-macro-hack-0.5.20+deprecated"
+        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.79.crate",
+        "sha256": "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e",
+        "dest": "cargo/vendor/proc-macro2-1.0.79"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068\", \"files\": {}}",
-        "dest": "cargo/vendor/proc-macro-hack-0.5.20+deprecated",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.66.crate",
-        "sha256": "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9",
-        "dest": "cargo/vendor/proc-macro2-1.0.66"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9\", \"files\": {}}",
-        "dest": "cargo/vendor/proc-macro2-1.0.66",
+        "contents": "{\"package\": \"e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro2-1.0.79",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2957,27 +3334,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.29.0.crate",
-        "sha256": "81b9228215d82c7b61490fec1de287136b5de6f5700f6e58ea9ad61a7964ca51",
-        "dest": "cargo/vendor/quick-xml-0.29.0"
+        "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.31.0.crate",
+        "sha256": "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33",
+        "dest": "cargo/vendor/quick-xml-0.31.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"81b9228215d82c7b61490fec1de287136b5de6f5700f6e58ea9ad61a7964ca51\", \"files\": {}}",
-        "dest": "cargo/vendor/quick-xml-0.29.0",
+        "contents": "{\"package\": \"1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33\", \"files\": {}}",
+        "dest": "cargo/vendor/quick-xml-0.31.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/quote/quote-1.0.33.crate",
-        "sha256": "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae",
-        "dest": "cargo/vendor/quote-1.0.33"
+        "url": "https://static.crates.io/crates/quote/quote-1.0.35.crate",
+        "sha256": "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef",
+        "dest": "cargo/vendor/quote-1.0.35"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae\", \"files\": {}}",
-        "dest": "cargo/vendor/quote-1.0.33",
+        "contents": "{\"package\": \"291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef\", \"files\": {}}",
+        "dest": "cargo/vendor/quote-1.0.35",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2996,92 +3373,105 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.2.16.crate",
-        "sha256": "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a",
-        "dest": "cargo/vendor/redox_syscall-0.2.16"
+        "url": "https://static.crates.io/crates/raw-window-handle/raw-window-handle-0.5.2.crate",
+        "sha256": "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9",
+        "dest": "cargo/vendor/raw-window-handle-0.5.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a\", \"files\": {}}",
-        "dest": "cargo/vendor/redox_syscall-0.2.16",
+        "contents": "{\"package\": \"f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9\", \"files\": {}}",
+        "dest": "cargo/vendor/raw-window-handle-0.5.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.3.5.crate",
-        "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
-        "dest": "cargo/vendor/redox_syscall-0.3.5"
+        "url": "https://static.crates.io/crates/raw-window-handle/raw-window-handle-0.6.0.crate",
+        "sha256": "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544",
+        "dest": "cargo/vendor/raw-window-handle-0.6.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29\", \"files\": {}}",
-        "dest": "cargo/vendor/redox_syscall-0.3.5",
+        "contents": "{\"package\": \"42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544\", \"files\": {}}",
+        "dest": "cargo/vendor/raw-window-handle-0.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/redox_users/redox_users-0.4.3.crate",
-        "sha256": "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b",
-        "dest": "cargo/vendor/redox_users-0.4.3"
+        "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.4.1.crate",
+        "sha256": "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa",
+        "dest": "cargo/vendor/redox_syscall-0.4.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b\", \"files\": {}}",
-        "dest": "cargo/vendor/redox_users-0.4.3",
+        "contents": "{\"package\": \"4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_syscall-0.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/regex/regex-1.9.4.crate",
-        "sha256": "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29",
-        "dest": "cargo/vendor/regex-1.9.4"
+        "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.5.1.crate",
+        "sha256": "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e",
+        "dest": "cargo/vendor/redox_syscall-0.5.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29\", \"files\": {}}",
-        "dest": "cargo/vendor/regex-1.9.4",
+        "contents": "{\"package\": \"469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_syscall-0.5.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/regex-automata/regex-automata-0.3.7.crate",
-        "sha256": "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629",
-        "dest": "cargo/vendor/regex-automata-0.3.7"
+        "url": "https://static.crates.io/crates/redox_users/redox_users-0.4.4.crate",
+        "sha256": "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4",
+        "dest": "cargo/vendor/redox_users-0.4.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629\", \"files\": {}}",
-        "dest": "cargo/vendor/regex-automata-0.3.7",
+        "contents": "{\"package\": \"a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_users-0.4.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.7.5.crate",
-        "sha256": "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da",
-        "dest": "cargo/vendor/regex-syntax-0.7.5"
+        "url": "https://static.crates.io/crates/regex/regex-1.10.4.crate",
+        "sha256": "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c",
+        "dest": "cargo/vendor/regex-1.10.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da\", \"files\": {}}",
-        "dest": "cargo/vendor/regex-syntax-0.7.5",
+        "contents": "{\"package\": \"c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-1.10.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ring/ring-0.16.20.crate",
-        "sha256": "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc",
-        "dest": "cargo/vendor/ring-0.16.20"
+        "url": "https://static.crates.io/crates/regex-automata/regex-automata-0.4.6.crate",
+        "sha256": "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea",
+        "dest": "cargo/vendor/regex-automata-0.4.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc\", \"files\": {}}",
-        "dest": "cargo/vendor/ring-0.16.20",
+        "contents": "{\"package\": \"86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-automata-0.4.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.8.3.crate",
+        "sha256": "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56",
+        "dest": "cargo/vendor/regex-syntax-0.8.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-syntax-0.8.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3126,19 +3516,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustc_version/rustc_version-0.3.3.crate",
-        "sha256": "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee",
-        "dest": "cargo/vendor/rustc_version-0.3.3"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee\", \"files\": {}}",
-        "dest": "cargo/vendor/rustc_version-0.3.3",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rustc_version/rustc_version-0.4.0.crate",
         "sha256": "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366",
         "dest": "cargo/vendor/rustc_version-0.4.0"
@@ -3152,53 +3529,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustix/rustix-0.38.11.crate",
-        "sha256": "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453",
-        "dest": "cargo/vendor/rustix-0.38.11"
+        "url": "https://static.crates.io/crates/rustix/rustix-0.38.32.crate",
+        "sha256": "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89",
+        "dest": "cargo/vendor/rustix-0.38.32"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453\", \"files\": {}}",
-        "dest": "cargo/vendor/rustix-0.38.11",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustls/rustls-0.21.7.crate",
-        "sha256": "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8",
-        "dest": "cargo/vendor/rustls-0.21.7"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8\", \"files\": {}}",
-        "dest": "cargo/vendor/rustls-0.21.7",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustls-webpki/rustls-webpki-0.100.2.crate",
-        "sha256": "e98ff011474fa39949b7e5c0428f9b4937eda7da7848bbb947786b7be0b27dab",
-        "dest": "cargo/vendor/rustls-webpki-0.100.2"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"e98ff011474fa39949b7e5c0428f9b4937eda7da7848bbb947786b7be0b27dab\", \"files\": {}}",
-        "dest": "cargo/vendor/rustls-webpki-0.100.2",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustls-webpki/rustls-webpki-0.101.4.crate",
-        "sha256": "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d",
-        "dest": "cargo/vendor/rustls-webpki-0.101.4"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d\", \"files\": {}}",
-        "dest": "cargo/vendor/rustls-webpki-0.101.4",
+        "contents": "{\"package\": \"65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89\", \"files\": {}}",
+        "dest": "cargo/vendor/rustix-0.38.32",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3217,27 +3555,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ryu/ryu-1.0.15.crate",
-        "sha256": "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741",
-        "dest": "cargo/vendor/ryu-1.0.15"
+        "url": "https://static.crates.io/crates/ryu/ryu-1.0.17.crate",
+        "sha256": "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1",
+        "dest": "cargo/vendor/ryu-1.0.17"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741\", \"files\": {}}",
-        "dest": "cargo/vendor/ryu-1.0.15",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/safemem/safemem-0.3.3.crate",
-        "sha256": "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072",
-        "dest": "cargo/vendor/safemem-0.3.3"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072\", \"files\": {}}",
-        "dest": "cargo/vendor/safemem-0.3.3",
+        "contents": "{\"package\": \"e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1\", \"files\": {}}",
+        "dest": "cargo/vendor/ryu-1.0.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3256,6 +3581,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/scoped-tls/scoped-tls-1.0.1.crate",
+        "sha256": "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294",
+        "dest": "cargo/vendor/scoped-tls-1.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294\", \"files\": {}}",
+        "dest": "cargo/vendor/scoped-tls-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/scopeguard/scopeguard-1.2.0.crate",
         "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
         "dest": "cargo/vendor/scopeguard-1.2.0"
@@ -3264,19 +3602,6 @@
         "type": "inline",
         "contents": "{\"package\": \"94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49\", \"files\": {}}",
         "dest": "cargo/vendor/scopeguard-1.2.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/sct/sct-0.7.0.crate",
-        "sha256": "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4",
-        "dest": "cargo/vendor/sct-0.7.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4\", \"files\": {}}",
-        "dest": "cargo/vendor/sct-0.7.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3308,92 +3633,66 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/semver/semver-0.11.0.crate",
-        "sha256": "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6",
-        "dest": "cargo/vendor/semver-0.11.0"
+        "url": "https://static.crates.io/crates/semver/semver-1.0.22.crate",
+        "sha256": "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca",
+        "dest": "cargo/vendor/semver-1.0.22"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6\", \"files\": {}}",
-        "dest": "cargo/vendor/semver-0.11.0",
+        "contents": "{\"package\": \"92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca\", \"files\": {}}",
+        "dest": "cargo/vendor/semver-1.0.22",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/semver/semver-1.0.18.crate",
-        "sha256": "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918",
-        "dest": "cargo/vendor/semver-1.0.18"
+        "url": "https://static.crates.io/crates/serde/serde-1.0.197.crate",
+        "sha256": "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2",
+        "dest": "cargo/vendor/serde-1.0.197"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918\", \"files\": {}}",
-        "dest": "cargo/vendor/semver-1.0.18",
+        "contents": "{\"package\": \"3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2\", \"files\": {}}",
+        "dest": "cargo/vendor/serde-1.0.197",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/semver-parser/semver-parser-0.10.2.crate",
-        "sha256": "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7",
-        "dest": "cargo/vendor/semver-parser-0.10.2"
+        "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.197.crate",
+        "sha256": "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b",
+        "dest": "cargo/vendor/serde_derive-1.0.197"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7\", \"files\": {}}",
-        "dest": "cargo/vendor/semver-parser-0.10.2",
+        "contents": "{\"package\": \"7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_derive-1.0.197",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde/serde-1.0.188.crate",
-        "sha256": "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e",
-        "dest": "cargo/vendor/serde-1.0.188"
+        "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.115.crate",
+        "sha256": "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd",
+        "dest": "cargo/vendor/serde_json-1.0.115"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e\", \"files\": {}}",
-        "dest": "cargo/vendor/serde-1.0.188",
+        "contents": "{\"package\": \"12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_json-1.0.115",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.188.crate",
-        "sha256": "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2",
-        "dest": "cargo/vendor/serde_derive-1.0.188"
+        "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-0.6.5.crate",
+        "sha256": "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1",
+        "dest": "cargo/vendor/serde_spanned-0.6.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2\", \"files\": {}}",
-        "dest": "cargo/vendor/serde_derive-1.0.188",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.105.crate",
-        "sha256": "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360",
-        "dest": "cargo/vendor/serde_json-1.0.105"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360\", \"files\": {}}",
-        "dest": "cargo/vendor/serde_json-1.0.105",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-0.6.4.crate",
-        "sha256": "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80",
-        "dest": "cargo/vendor/serde_spanned-0.6.4"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80\", \"files\": {}}",
-        "dest": "cargo/vendor/serde_spanned-0.6.4",
+        "contents": "{\"package\": \"eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_spanned-0.6.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3425,14 +3724,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/shlex/shlex-1.1.0.crate",
-        "sha256": "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3",
-        "dest": "cargo/vendor/shlex-1.1.0"
+        "url": "https://static.crates.io/crates/shlex/shlex-1.3.0.crate",
+        "sha256": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
+        "dest": "cargo/vendor/shlex-1.3.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3\", \"files\": {}}",
-        "dest": "cargo/vendor/shlex-1.1.0",
+        "contents": "{\"package\": \"0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64\", \"files\": {}}",
+        "dest": "cargo/vendor/shlex-1.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3464,27 +3763,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/skia-bindings/skia-bindings-0.62.0.crate",
-        "sha256": "a1a212f303074c5ef1f4bead4de67db0c91f56aa5da8e75f622869414a0e41a8",
-        "dest": "cargo/vendor/skia-bindings-0.62.0"
+        "url": "https://static.crates.io/crates/skia-bindings/skia-bindings-0.70.0.crate",
+        "sha256": "4bc61a106126a429bb4775ce5fbe23b2bcaa74d1a9c484997f4700de31480b44",
+        "dest": "cargo/vendor/skia-bindings-0.70.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a1a212f303074c5ef1f4bead4de67db0c91f56aa5da8e75f622869414a0e41a8\", \"files\": {}}",
-        "dest": "cargo/vendor/skia-bindings-0.62.0",
+        "contents": "{\"package\": \"4bc61a106126a429bb4775ce5fbe23b2bcaa74d1a9c484997f4700de31480b44\", \"files\": {}}",
+        "dest": "cargo/vendor/skia-bindings-0.70.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/skia-safe/skia-safe-0.62.0.crate",
-        "sha256": "c6fb5ab010b9e90ab2d639650ddb2cba6bfad6d8742f93131968de865abc2c4a",
-        "dest": "cargo/vendor/skia-safe-0.62.0"
+        "url": "https://static.crates.io/crates/skia-safe/skia-safe-0.70.0.crate",
+        "sha256": "3201eba92bca1f83864f5c3a48309bcfee7e0590bebd7826e7ab0a49aa24a750",
+        "dest": "cargo/vendor/skia-safe-0.70.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c6fb5ab010b9e90ab2d639650ddb2cba6bfad6d8742f93131968de865abc2c4a\", \"files\": {}}",
-        "dest": "cargo/vendor/skia-safe-0.62.0",
+        "contents": "{\"package\": \"3201eba92bca1f83864f5c3a48309bcfee7e0590bebd7826e7ab0a49aa24a750\", \"files\": {}}",
+        "dest": "cargo/vendor/skia-safe-0.70.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3503,27 +3802,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/smallvec/smallvec-1.11.0.crate",
-        "sha256": "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9",
-        "dest": "cargo/vendor/smallvec-1.11.0"
+        "url": "https://static.crates.io/crates/smallvec/smallvec-1.13.2.crate",
+        "sha256": "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67",
+        "dest": "cargo/vendor/smallvec-1.13.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9\", \"files\": {}}",
-        "dest": "cargo/vendor/smallvec-1.11.0",
+        "contents": "{\"package\": \"3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67\", \"files\": {}}",
+        "dest": "cargo/vendor/smallvec-1.13.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/spin/spin-0.5.2.crate",
-        "sha256": "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d",
-        "dest": "cargo/vendor/spin-0.5.2"
+        "type": "shell",
+        "commands": [
+            "cp -r --reflink=auto \"flatpak-cargo/git/softbuffer-5c7a209/.\" \"cargo/vendor/softbuffer\""
+        ]
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d\", \"files\": {}}",
-        "dest": "cargo/vendor/spin-0.5.2",
+        "contents": "[[bench]]\nname = \"buffer_mut\"\nharness = false\n\n[[test]]\nname = \"present_and_fetch\"\npath = \"tests/present_and_fetch.rs\"\nharness = false\n\n[package]\nname = \"softbuffer\"\nversion = \"0.4.1\"\nedition = \"2021\"\nlicense = \"MIT OR Apache-2.0\"\ndescription = \"Cross-platform software buffer\"\ndocumentation = \"https://docs.rs/softbuffer\"\nreadme = \"README.md\"\nrepository = \"https://github.com/rust-windowing/softbuffer\"\nkeywords = [ \"framebuffer\", \"windowing\",]\ncategories = [ \"game-development\", \"graphics\", \"gui\", \"multimedia\", \"rendering\",]\nexclude = [ \"examples\",]\nrust-version = \"1.65.0\"\n\n[features]\ndefault = [ \"kms\", \"x11\", \"x11-dlopen\", \"wayland\", \"wayland-dlopen\",]\nkms = [ \"bytemuck\", \"drm\", \"rustix\",]\nwayland = [ \"wayland-backend\", \"wayland-client\", \"memmap2\", \"rustix\", \"fastrand\",]\nwayland-dlopen = [ \"wayland-sys/dlopen\",]\nx11 = [ \"as-raw-xcb-connection\", \"bytemuck\", \"fastrand\", \"rustix\", \"tiny-xlib\", \"x11rb\",]\nx11-dlopen = [ \"tiny-xlib/dlopen\", \"x11rb/dl-libxcb\",]\n\n[dependencies]\nlog = \"0.4.17\"\n\n[build-dependencies]\ncfg_aliases = \"0.2.0\"\n\n[dev-dependencies]\ncolorous = \"1.0.12\"\ninstant = \"0.1.12\"\nwinit = \"0.29.2\"\nwinit-test = \"0.1.0\"\n\n[workspace]\nmembers = [ \"run-wasm\",]\n\n[dependencies.raw_window_handle]\npackage = \"raw-window-handle\"\nversion = \"0.6\"\nfeatures = [ \"std\",]\n\n[dev-dependencies.criterion]\nversion = \"0.4.0\"\ndefault-features = false\nfeatures = [ \"cargo_bench_support\",]\n\n[dev-dependencies.image]\nversion = \"0.24.6\"\ndefault-features = false\nfeatures = [ \"jpeg\",]\n\n[target.\"cfg(all(unix, not(any(target_vendor = \\\"apple\\\", target_os = \\\"android\\\", target_os = \\\"redox\\\"))))\".dependencies]\nwayland-sys = \"0.31.0\"\n\n[target.\"cfg(target_os = \\\"macos\\\")\".dependencies]\ncocoa = \"0.25.0\"\ncore-graphics = \"0.23.1\"\nforeign-types = \"0.5.0\"\nobjc = \"0.2.7\"\n\n[target.\"cfg(target_arch = \\\"wasm32\\\")\".dependencies]\njs-sys = \"0.3.63\"\nwasm-bindgen = \"0.2.86\"\n\n[target.\"cfg(target_arch = \\\"wasm32\\\")\".dev-dependencies]\nwasm-bindgen-test = \"0.3\"\n\n[target.\"cfg(target_os = \\\"redox\\\")\".dependencies]\nredox_syscall = \"0.5\"\n\n[target.\"cfg(not(target_arch = \\\"wasm32\\\"))\".dev-dependencies]\nimage = \"0.24.6\"\nrayon = \"1.5.1\"\n\n[package.metadata.docs.rs]\nall-features = true\nrustdoc-args = [ \"--cfg\", \"docsrs\",]\ndefault-target = \"x86_64-unknown-linux-gnu\"\ntargets = [ \"x86_64-pc-windows-msvc\", \"x86_64-apple-darwin\", \"x86_64-unknown-linux-gnu\", \"wasm32-unknown-unknown\",]\n\n[target.\"cfg(all(unix, not(any(target_vendor = \\\"apple\\\", target_os = \\\"android\\\", target_os = \\\"redox\\\"))))\".dependencies.as-raw-xcb-connection]\nversion = \"1.0.0\"\noptional = true\n\n[target.\"cfg(all(unix, not(any(target_vendor = \\\"apple\\\", target_os = \\\"android\\\", target_os = \\\"redox\\\"))))\".dependencies.bytemuck]\nversion = \"1.12.3\"\noptional = true\n\n[target.\"cfg(all(unix, not(any(target_vendor = \\\"apple\\\", target_os = \\\"android\\\", target_os = \\\"redox\\\"))))\".dependencies.drm]\nversion = \"0.11.0\"\ndefault-features = false\noptional = true\n\n[target.\"cfg(all(unix, not(any(target_vendor = \\\"apple\\\", target_os = \\\"android\\\", target_os = \\\"redox\\\"))))\".dependencies.fastrand]\nversion = \"2.0.0\"\noptional = true\n\n[target.\"cfg(all(unix, not(any(target_vendor = \\\"apple\\\", target_os = \\\"android\\\", target_os = \\\"redox\\\"))))\".dependencies.memmap2]\nversion = \"0.9.0\"\noptional = true\n\n[target.\"cfg(all(unix, not(any(target_vendor = \\\"apple\\\", target_os = \\\"android\\\", target_os = \\\"redox\\\"))))\".dependencies.rustix]\nversion = \"0.38.19\"\nfeatures = [ \"fs\", \"mm\", \"shm\", \"std\",]\ndefault-features = false\noptional = true\n\n[target.\"cfg(all(unix, not(any(target_vendor = \\\"apple\\\", target_os = \\\"android\\\", target_os = \\\"redox\\\"))))\".dependencies.tiny-xlib]\nversion = \"0.2.1\"\noptional = true\n\n[target.\"cfg(all(unix, not(any(target_vendor = \\\"apple\\\", target_os = \\\"android\\\", target_os = \\\"redox\\\"))))\".dependencies.wayland-backend]\nversion = \"0.3.0\"\nfeatures = [ \"client_system\",]\noptional = true\n\n[target.\"cfg(all(unix, not(any(target_vendor = \\\"apple\\\", target_os = \\\"android\\\", target_os = \\\"redox\\\"))))\".dependencies.wayland-client]\nversion = \"0.31.0\"\noptional = true\n\n[target.\"cfg(all(unix, not(any(target_vendor = \\\"apple\\\", target_os = \\\"android\\\", target_os = \\\"redox\\\"))))\".dependencies.x11rb]\nversion = \"0.13.0\"\nfeatures = [ \"allow-unsafe-code\", \"shm\",]\noptional = true\n\n[target.\"cfg(all(unix, not(any(target_vendor = \\\"apple\\\", target_os = \\\"android\\\", target_os = \\\"redox\\\"))))\".dev-dependencies.rustix]\nversion = \"0.38.8\"\nfeatures = [ \"event\",]\n\n[target.\"cfg(target_os = \\\"windows\\\")\".dependencies.windows-sys]\nversion = \"0.52.0\"\nfeatures = [ \"Win32_Graphics_Gdi\", \"Win32_UI_WindowsAndMessaging\", \"Win32_Foundation\",]\n\n[target.\"cfg(target_os = \\\"macos\\\")\".dependencies.bytemuck]\nversion = \"1.12.3\"\nfeatures = [ \"extern_crate_alloc\",]\n\n[target.\"cfg(target_arch = \\\"wasm32\\\")\".dependencies.web-sys]\nversion = \"0.3.55\"\nfeatures = [ \"CanvasRenderingContext2d\", \"Document\", \"Element\", \"HtmlCanvasElement\", \"ImageData\", \"OffscreenCanvas\", \"OffscreenCanvasRenderingContext2d\", \"Window\",]\n",
+        "dest": "cargo/vendor/softbuffer",
+        "dest-filename": "Cargo.toml"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": null, \"files\": {}}",
+        "dest": "cargo/vendor/softbuffer",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3651,14 +3955,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/syn/syn-2.0.32.crate",
-        "sha256": "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2",
-        "dest": "cargo/vendor/syn-2.0.32"
+        "url": "https://static.crates.io/crates/syn/syn-2.0.55.crate",
+        "sha256": "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0",
+        "dest": "cargo/vendor/syn-2.0.55"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2\", \"files\": {}}",
-        "dest": "cargo/vendor/syn-2.0.32",
+        "contents": "{\"package\": \"002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0\", \"files\": {}}",
+        "dest": "cargo/vendor/syn-2.0.55",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3690,53 +3994,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/termcolor/termcolor-1.2.0.crate",
-        "sha256": "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6",
-        "dest": "cargo/vendor/termcolor-1.2.0"
+        "url": "https://static.crates.io/crates/termcolor/termcolor-1.4.1.crate",
+        "sha256": "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755",
+        "dest": "cargo/vendor/termcolor-1.4.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6\", \"files\": {}}",
-        "dest": "cargo/vendor/termcolor-1.2.0",
+        "contents": "{\"package\": \"06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755\", \"files\": {}}",
+        "dest": "cargo/vendor/termcolor-1.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/textwrap/textwrap-0.16.0.crate",
-        "sha256": "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d",
-        "dest": "cargo/vendor/textwrap-0.16.0"
+        "url": "https://static.crates.io/crates/textwrap/textwrap-0.16.1.crate",
+        "sha256": "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9",
+        "dest": "cargo/vendor/textwrap-0.16.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d\", \"files\": {}}",
-        "dest": "cargo/vendor/textwrap-0.16.0",
+        "contents": "{\"package\": \"23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9\", \"files\": {}}",
+        "dest": "cargo/vendor/textwrap-0.16.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.47.crate",
-        "sha256": "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f",
-        "dest": "cargo/vendor/thiserror-1.0.47"
+        "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.58.crate",
+        "sha256": "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297",
+        "dest": "cargo/vendor/thiserror-1.0.58"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f\", \"files\": {}}",
-        "dest": "cargo/vendor/thiserror-1.0.47",
+        "contents": "{\"package\": \"03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-1.0.58",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.47.crate",
-        "sha256": "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b",
-        "dest": "cargo/vendor/thiserror-impl-1.0.47"
+        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.58.crate",
+        "sha256": "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7",
+        "dest": "cargo/vendor/thiserror-impl-1.0.58"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b\", \"files\": {}}",
-        "dest": "cargo/vendor/thiserror-impl-1.0.47",
+        "contents": "{\"package\": \"c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-impl-1.0.58",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3755,79 +4059,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/time/time-0.1.45.crate",
-        "sha256": "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a",
-        "dest": "cargo/vendor/time-0.1.45"
+        "url": "https://static.crates.io/crates/time/time-0.3.34.crate",
+        "sha256": "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749",
+        "dest": "cargo/vendor/time-0.3.34"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a\", \"files\": {}}",
-        "dest": "cargo/vendor/time-0.1.45",
+        "contents": "{\"package\": \"c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749\", \"files\": {}}",
+        "dest": "cargo/vendor/time-0.3.34",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/time/time-0.3.28.crate",
-        "sha256": "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48",
-        "dest": "cargo/vendor/time-0.3.28"
+        "url": "https://static.crates.io/crates/time-core/time-core-0.1.2.crate",
+        "sha256": "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3",
+        "dest": "cargo/vendor/time-core-0.1.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48\", \"files\": {}}",
-        "dest": "cargo/vendor/time-0.3.28",
+        "contents": "{\"package\": \"ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3\", \"files\": {}}",
+        "dest": "cargo/vendor/time-core-0.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/time-core/time-core-0.1.1.crate",
-        "sha256": "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb",
-        "dest": "cargo/vendor/time-core-0.1.1"
+        "url": "https://static.crates.io/crates/time-macros/time-macros-0.2.17.crate",
+        "sha256": "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774",
+        "dest": "cargo/vendor/time-macros-0.2.17"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb\", \"files\": {}}",
-        "dest": "cargo/vendor/time-core-0.1.1",
+        "contents": "{\"package\": \"7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774\", \"files\": {}}",
+        "dest": "cargo/vendor/time-macros-0.2.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/time-macros/time-macros-0.2.14.crate",
-        "sha256": "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572",
-        "dest": "cargo/vendor/time-macros-0.2.14"
+        "url": "https://static.crates.io/crates/tiny-xlib/tiny-xlib-0.2.2.crate",
+        "sha256": "d4098d49269baa034a8d1eae9bd63e9fa532148d772121dace3bcd6a6c98eb6d",
+        "dest": "cargo/vendor/tiny-xlib-0.2.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572\", \"files\": {}}",
-        "dest": "cargo/vendor/time-macros-0.2.14",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tinyvec/tinyvec-1.6.0.crate",
-        "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50",
-        "dest": "cargo/vendor/tinyvec-1.6.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50\", \"files\": {}}",
-        "dest": "cargo/vendor/tinyvec-1.6.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tinyvec_macros/tinyvec_macros-0.1.1.crate",
-        "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20",
-        "dest": "cargo/vendor/tinyvec_macros-0.1.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20\", \"files\": {}}",
-        "dest": "cargo/vendor/tinyvec_macros-0.1.1",
+        "contents": "{\"package\": \"d4098d49269baa034a8d1eae9bd63e9fa532148d772121dace3bcd6a6c98eb6d\", \"files\": {}}",
+        "dest": "cargo/vendor/tiny-xlib-0.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3846,14 +4124,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml/toml-0.7.8.crate",
-        "sha256": "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257",
-        "dest": "cargo/vendor/toml-0.7.8"
+        "url": "https://static.crates.io/crates/toml/toml-0.8.12.crate",
+        "sha256": "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3",
+        "dest": "cargo/vendor/toml-0.8.12"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257\", \"files\": {}}",
-        "dest": "cargo/vendor/toml-0.7.8",
+        "contents": "{\"package\": \"e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3\", \"files\": {}}",
+        "dest": "cargo/vendor/toml-0.8.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3872,14 +4150,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.19.15.crate",
-        "sha256": "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421",
-        "dest": "cargo/vendor/toml_edit-0.19.15"
+        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.22.9.crate",
+        "sha256": "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4",
+        "dest": "cargo/vendor/toml_edit-0.22.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_edit-0.19.15",
+        "contents": "{\"package\": \"8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_edit-0.22.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tracing/tracing-0.1.40.crate",
+        "sha256": "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef",
+        "dest": "cargo/vendor/tracing-0.1.40"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef\", \"files\": {}}",
+        "dest": "cargo/vendor/tracing-0.1.40",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tracing-core/tracing-core-0.1.32.crate",
+        "sha256": "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54",
+        "dest": "cargo/vendor/tracing-core-0.1.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54\", \"files\": {}}",
+        "dest": "cargo/vendor/tracing-core-0.1.32",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3898,118 +4202,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ttf-parser/ttf-parser-0.19.1.crate",
-        "sha256": "a464a4b34948a5f67fddd2b823c62d9d92e44be75058b99939eae6c5b6960b33",
-        "dest": "cargo/vendor/ttf-parser-0.19.1"
+        "url": "https://static.crates.io/crates/ttf-parser/ttf-parser-0.20.0.crate",
+        "sha256": "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4",
+        "dest": "cargo/vendor/ttf-parser-0.20.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a464a4b34948a5f67fddd2b823c62d9d92e44be75058b99939eae6c5b6960b33\", \"files\": {}}",
-        "dest": "cargo/vendor/ttf-parser-0.19.1",
+        "contents": "{\"package\": \"17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4\", \"files\": {}}",
+        "dest": "cargo/vendor/ttf-parser-0.20.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ucd-trie/ucd-trie-0.1.6.crate",
-        "sha256": "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9",
-        "dest": "cargo/vendor/ucd-trie-0.1.6"
+        "url": "https://static.crates.io/crates/unicode-ident/unicode-ident-1.0.12.crate",
+        "sha256": "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b",
+        "dest": "cargo/vendor/unicode-ident-1.0.12"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9\", \"files\": {}}",
-        "dest": "cargo/vendor/ucd-trie-0.1.6",
+        "contents": "{\"package\": \"3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-ident-1.0.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-bidi/unicode-bidi-0.3.13.crate",
-        "sha256": "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460",
-        "dest": "cargo/vendor/unicode-bidi-0.3.13"
+        "url": "https://static.crates.io/crates/unicode-segmentation/unicode-segmentation-1.11.0.crate",
+        "sha256": "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202",
+        "dest": "cargo/vendor/unicode-segmentation-1.11.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460\", \"files\": {}}",
-        "dest": "cargo/vendor/unicode-bidi-0.3.13",
+        "contents": "{\"package\": \"d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-segmentation-1.11.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-ident/unicode-ident-1.0.11.crate",
-        "sha256": "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c",
-        "dest": "cargo/vendor/unicode-ident-1.0.11"
+        "url": "https://static.crates.io/crates/unicode_names2/unicode_names2-0.6.0.crate",
+        "sha256": "446c96c6dd42604779487f0a981060717156648c1706aa1f464677f03c6cc059",
+        "dest": "cargo/vendor/unicode_names2-0.6.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c\", \"files\": {}}",
-        "dest": "cargo/vendor/unicode-ident-1.0.11",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-normalization/unicode-normalization-0.1.22.crate",
-        "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921",
-        "dest": "cargo/vendor/unicode-normalization-0.1.22"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921\", \"files\": {}}",
-        "dest": "cargo/vendor/unicode-normalization-0.1.22",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-segmentation/unicode-segmentation-1.10.1.crate",
-        "sha256": "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36",
-        "dest": "cargo/vendor/unicode-segmentation-1.10.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36\", \"files\": {}}",
-        "dest": "cargo/vendor/unicode-segmentation-1.10.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/untrusted/untrusted-0.7.1.crate",
-        "sha256": "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a",
-        "dest": "cargo/vendor/untrusted-0.7.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a\", \"files\": {}}",
-        "dest": "cargo/vendor/untrusted-0.7.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ureq/ureq-2.7.1.crate",
-        "sha256": "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9",
-        "dest": "cargo/vendor/ureq-2.7.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9\", \"files\": {}}",
-        "dest": "cargo/vendor/ureq-2.7.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/url/url-2.4.1.crate",
-        "sha256": "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5",
-        "dest": "cargo/vendor/url-2.4.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5\", \"files\": {}}",
-        "dest": "cargo/vendor/url-2.4.1",
+        "contents": "{\"package\": \"446c96c6dd42604779487f0a981060717156648c1706aa1f464677f03c6cc059\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode_names2-0.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4054,27 +4293,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/walkdir/walkdir-2.3.3.crate",
-        "sha256": "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698",
-        "dest": "cargo/vendor/walkdir-2.3.3"
+        "url": "https://static.crates.io/crates/walkdir/walkdir-2.5.0.crate",
+        "sha256": "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b",
+        "dest": "cargo/vendor/walkdir-2.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698\", \"files\": {}}",
-        "dest": "cargo/vendor/walkdir-2.3.3",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasi/wasi-0.10.0+wasi-snapshot-preview1.crate",
-        "sha256": "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f",
-        "dest": "cargo/vendor/wasi-0.10.0+wasi-snapshot-preview1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f\", \"files\": {}}",
-        "dest": "cargo/vendor/wasi-0.10.0+wasi-snapshot-preview1",
+        "contents": "{\"package\": \"29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b\", \"files\": {}}",
+        "dest": "cargo/vendor/walkdir-2.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4093,118 +4319,157 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.87.crate",
-        "sha256": "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342",
-        "dest": "cargo/vendor/wasm-bindgen-0.2.87"
+        "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.92.crate",
+        "sha256": "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8",
+        "dest": "cargo/vendor/wasm-bindgen-0.2.92"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-0.2.87",
+        "contents": "{\"package\": \"4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-0.2.92",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-backend/wasm-bindgen-backend-0.2.87.crate",
-        "sha256": "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd",
-        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.87"
+        "url": "https://static.crates.io/crates/wasm-bindgen-backend/wasm-bindgen-backend-0.2.92.crate",
+        "sha256": "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da",
+        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.92"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.87",
+        "contents": "{\"package\": \"614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.92",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.87.crate",
-        "sha256": "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d",
-        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.87"
+        "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.92.crate",
+        "sha256": "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726",
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.92"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.87",
+        "contents": "{\"package\": \"a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.92",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.87.crate",
-        "sha256": "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b",
-        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.87"
+        "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.92.crate",
+        "sha256": "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7",
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.92"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.87",
+        "contents": "{\"package\": \"e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.92",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.87.crate",
-        "sha256": "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1",
-        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.87"
+        "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.92.crate",
+        "sha256": "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96",
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.92"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.87",
+        "contents": "{\"package\": \"af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.92",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/web-sys/web-sys-0.3.64.crate",
-        "sha256": "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b",
-        "dest": "cargo/vendor/web-sys-0.3.64"
+        "url": "https://static.crates.io/crates/wayland-backend/wayland-backend-0.3.3.crate",
+        "sha256": "9d50fa61ce90d76474c87f5fc002828d81b32677340112b4ef08079a9d459a40",
+        "dest": "cargo/vendor/wayland-backend-0.3.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b\", \"files\": {}}",
-        "dest": "cargo/vendor/web-sys-0.3.64",
+        "contents": "{\"package\": \"9d50fa61ce90d76474c87f5fc002828d81b32677340112b4ef08079a9d459a40\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-backend-0.3.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/webpki-roots/webpki-roots-0.23.1.crate",
-        "sha256": "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338",
-        "dest": "cargo/vendor/webpki-roots-0.23.1"
+        "url": "https://static.crates.io/crates/wayland-client/wayland-client-0.31.2.crate",
+        "sha256": "82fb96ee935c2cea6668ccb470fb7771f6215d1691746c2d896b447a00ad3f1f",
+        "dest": "cargo/vendor/wayland-client-0.31.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338\", \"files\": {}}",
-        "dest": "cargo/vendor/webpki-roots-0.23.1",
+        "contents": "{\"package\": \"82fb96ee935c2cea6668ccb470fb7771f6215d1691746c2d896b447a00ad3f1f\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-client-0.31.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/weezl/weezl-0.1.7.crate",
-        "sha256": "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb",
-        "dest": "cargo/vendor/weezl-0.1.7"
+        "url": "https://static.crates.io/crates/wayland-scanner/wayland-scanner-0.31.1.crate",
+        "sha256": "63b3a62929287001986fb58c789dce9b67604a397c15c611ad9f747300b6c283",
+        "dest": "cargo/vendor/wayland-scanner-0.31.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb\", \"files\": {}}",
-        "dest": "cargo/vendor/weezl-0.1.7",
+        "contents": "{\"package\": \"63b3a62929287001986fb58c789dce9b67604a397c15c611ad9f747300b6c283\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-scanner-0.31.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/which/which-4.4.0.crate",
-        "sha256": "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269",
-        "dest": "cargo/vendor/which-4.4.0"
+        "url": "https://static.crates.io/crates/wayland-sys/wayland-sys-0.31.1.crate",
+        "sha256": "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af",
+        "dest": "cargo/vendor/wayland-sys-0.31.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269\", \"files\": {}}",
-        "dest": "cargo/vendor/which-4.4.0",
+        "contents": "{\"package\": \"15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-sys-0.31.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/web-sys/web-sys-0.3.69.crate",
+        "sha256": "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef",
+        "dest": "cargo/vendor/web-sys-0.3.69"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef\", \"files\": {}}",
+        "dest": "cargo/vendor/web-sys-0.3.69",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/weezl/weezl-0.1.8.crate",
+        "sha256": "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082",
+        "dest": "cargo/vendor/weezl-0.1.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082\", \"files\": {}}",
+        "dest": "cargo/vendor/weezl-0.1.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/which/which-4.4.2.crate",
+        "sha256": "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7",
+        "dest": "cargo/vendor/which-4.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7\", \"files\": {}}",
+        "dest": "cargo/vendor/which-4.4.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4236,14 +4501,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/winapi-util/winapi-util-0.1.5.crate",
-        "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
-        "dest": "cargo/vendor/winapi-util-0.1.5"
+        "url": "https://static.crates.io/crates/winapi-util/winapi-util-0.1.6.crate",
+        "sha256": "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596",
+        "dest": "cargo/vendor/winapi-util-0.1.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178\", \"files\": {}}",
-        "dest": "cargo/vendor/winapi-util-0.1.5",
+        "contents": "{\"package\": \"f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-util-0.1.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4275,14 +4540,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/windows/windows-0.48.0.crate",
-        "sha256": "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f",
-        "dest": "cargo/vendor/windows-0.48.0"
+        "url": "https://static.crates.io/crates/windows-core/windows-core-0.52.0.crate",
+        "sha256": "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9",
+        "dest": "cargo/vendor/windows-core-0.52.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f\", \"files\": {}}",
-        "dest": "cargo/vendor/windows-0.48.0",
+        "contents": "{\"package\": \"33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-core-0.52.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4314,6 +4579,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.52.0.crate",
+        "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
+        "dest": "cargo/vendor/windows-sys-0.52.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.52.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.42.2.crate",
         "sha256": "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071",
         "dest": "cargo/vendor/windows-targets-0.42.2"
@@ -4335,6 +4613,19 @@
         "type": "inline",
         "contents": "{\"package\": \"9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c\", \"files\": {}}",
         "dest": "cargo/vendor/windows-targets-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.52.4.crate",
+        "sha256": "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b",
+        "dest": "cargo/vendor/windows-targets-0.52.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-targets-0.52.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4366,6 +4657,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.52.4.crate",
+        "sha256": "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.42.2.crate",
         "sha256": "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43",
         "dest": "cargo/vendor/windows_aarch64_msvc-0.42.2"
@@ -4387,6 +4691,19 @@
         "type": "inline",
         "contents": "{\"package\": \"dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc\", \"files\": {}}",
         "dest": "cargo/vendor/windows_aarch64_msvc-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.52.4.crate",
+        "sha256": "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.52.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.52.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4418,6 +4735,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.52.4.crate",
+        "sha256": "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3",
+        "dest": "cargo/vendor/windows_i686_gnu-0.52.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnu-0.52.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.42.2.crate",
         "sha256": "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060",
         "dest": "cargo/vendor/windows_i686_msvc-0.42.2"
@@ -4439,6 +4769,19 @@
         "type": "inline",
         "contents": "{\"package\": \"8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406\", \"files\": {}}",
         "dest": "cargo/vendor/windows_i686_msvc-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.52.4.crate",
+        "sha256": "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02",
+        "dest": "cargo/vendor/windows_i686_msvc-0.52.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_msvc-0.52.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4470,6 +4813,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.52.4.crate",
+        "sha256": "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.52.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.52.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.42.2.crate",
         "sha256": "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3",
         "dest": "cargo/vendor/windows_x86_64_gnullvm-0.42.2"
@@ -4491,6 +4847,19 @@
         "type": "inline",
         "contents": "{\"package\": \"0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc\", \"files\": {}}",
         "dest": "cargo/vendor/windows_x86_64_gnullvm-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.52.4.crate",
+        "sha256": "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4522,14 +4891,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/winnow/winnow-0.5.19.crate",
-        "sha256": "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b",
-        "dest": "cargo/vendor/winnow-0.5.19"
+        "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.52.4.crate",
+        "sha256": "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.52.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b\", \"files\": {}}",
-        "dest": "cargo/vendor/winnow-0.5.19",
+        "contents": "{\"package\": \"32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.52.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winnow/winnow-0.6.5.crate",
+        "sha256": "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8",
+        "dest": "cargo/vendor/winnow-0.6.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8\", \"files\": {}}",
+        "dest": "cargo/vendor/winnow-0.6.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4561,27 +4943,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/xattr/xattr-1.0.1.crate",
-        "sha256": "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985",
-        "dest": "cargo/vendor/xattr-1.0.1"
+        "url": "https://static.crates.io/crates/x11rb/x11rb-0.13.0.crate",
+        "sha256": "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a",
+        "dest": "cargo/vendor/x11rb-0.13.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985\", \"files\": {}}",
-        "dest": "cargo/vendor/xattr-1.0.1",
+        "contents": "{\"package\": \"f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a\", \"files\": {}}",
+        "dest": "cargo/vendor/x11rb-0.13.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/xml-rs/xml-rs-0.8.16.crate",
-        "sha256": "47430998a7b5d499ccee752b41567bc3afc57e1327dc855b1a2aa44ce29b5fa1",
-        "dest": "cargo/vendor/xml-rs-0.8.16"
+        "url": "https://static.crates.io/crates/x11rb-protocol/x11rb-protocol-0.13.0.crate",
+        "sha256": "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34",
+        "dest": "cargo/vendor/x11rb-protocol-0.13.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"47430998a7b5d499ccee752b41567bc3afc57e1327dc855b1a2aa44ce29b5fa1\", \"files\": {}}",
-        "dest": "cargo/vendor/xml-rs-0.8.16",
+        "contents": "{\"package\": \"e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34\", \"files\": {}}",
+        "dest": "cargo/vendor/x11rb-protocol-0.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xattr/xattr-1.3.1.crate",
+        "sha256": "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f",
+        "dest": "cargo/vendor/xattr-1.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f\", \"files\": {}}",
+        "dest": "cargo/vendor/xattr-1.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xml-rs/xml-rs-0.8.19.crate",
+        "sha256": "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a",
+        "dest": "cargo/vendor/xml-rs-0.8.19"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a\", \"files\": {}}",
+        "dest": "cargo/vendor/xml-rs-0.8.19",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4598,8 +5006,34 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerocopy/zerocopy-0.7.32.crate",
+        "sha256": "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be",
+        "dest": "cargo/vendor/zerocopy-0.7.32"
+    },
+    {
         "type": "inline",
-        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.\"https://github.com/mfek/math.rlib\"]\ngit = \"https://github.com/mfek/math.rlib\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/mfek/chrono-locale.rlib\"]\ngit = \"https://github.com/mfek/chrono-locale.rlib\"\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/mfek/glifparser.rlib\"]\ngit = \"https://github.com/mfek/glifparser.rlib\"\nreplace-with = \"vendored-sources\"\nbranch = \"master\"\n\n[source.\"https://github.com/mfek/glifrenderer.rlib\"]\ngit = \"https://github.com/mfek/glifrenderer.rlib\"\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/mfek/kurbo.rlib\"]\ngit = \"https://github.com/mfek/kurbo.rlib\"\nreplace-with = \"vendored-sources\"\nbranch = \"master\"\n\n[source.\"https://github.com/mfek/ipc.rlib\"]\ngit = \"https://github.com/mfek/ipc.rlib\"\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/mfek/nfd.rs\"]\ngit = \"https://github.com/mfek/nfd.rs\"\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/mfek/pub_mod.rlib\"]\ngit = \"https://github.com/mfek/pub_mod.rlib\"\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/mfek/spline.rlib\"]\ngit = \"https://github.com/mfek/spline.rlib\"\nreplace-with = \"vendored-sources\"\n",
+        "contents": "{\"package\": \"74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be\", \"files\": {}}",
+        "dest": "cargo/vendor/zerocopy-0.7.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerocopy-derive/zerocopy-derive-0.7.32.crate",
+        "sha256": "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6",
+        "dest": "cargo/vendor/zerocopy-derive-0.7.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6\", \"files\": {}}",
+        "dest": "cargo/vendor/zerocopy-derive-0.7.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "inline",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.\"https://github.com/mfek/math.rlib\"]\ngit = \"https://github.com/mfek/math.rlib\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/mfek/chrono-locale.rlib\"]\ngit = \"https://github.com/mfek/chrono-locale.rlib\"\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/mfek/egui.rlib\"]\ngit = \"https://github.com/mfek/egui.rlib\"\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/mfek/egui-sdl2-event.rlib\"]\ngit = \"https://github.com/mfek/egui-sdl2-event.rlib\"\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/mfek/egui_skia.rlib\"]\ngit = \"https://github.com/mfek/egui_skia.rlib\"\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/mfek/glifparser.rlib\"]\ngit = \"https://github.com/mfek/glifparser.rlib\"\nreplace-with = \"vendored-sources\"\nbranch = \"master\"\n\n[source.\"https://github.com/mfek/glifrenderer.rlib\"]\ngit = \"https://github.com/mfek/glifrenderer.rlib\"\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/mfek/kurbo.rlib\"]\ngit = \"https://github.com/mfek/kurbo.rlib\"\nreplace-with = \"vendored-sources\"\nbranch = \"master\"\n\n[source.\"https://github.com/mfek/ipc.rlib\"]\ngit = \"https://github.com/mfek/ipc.rlib\"\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/mfek/nfd.rs\"]\ngit = \"https://github.com/mfek/nfd.rs\"\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/servo/pathfinder\"]\ngit = \"https://github.com/servo/pathfinder\"\nreplace-with = \"vendored-sources\"\nrev = \"30419d07660dc11a21e42ef4a7fa329600cff152\"\n\n[source.\"https://github.com/mfek/pub_mod.rlib\"]\ngit = \"https://github.com/mfek/pub_mod.rlib\"\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/john01dav/softbuffer\"]\ngit = \"https://github.com/john01dav/softbuffer\"\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/mfek/spline.rlib\"]\ngit = \"https://github.com/mfek/spline.rlib\"\nreplace-with = \"vendored-sources\"\n",
         "dest": "cargo",
         "dest-filename": "config"
     }

--- a/org.mfek.MFEKglif.metainfo.xml
+++ b/org.mfek.MFEKglif.metainfo.xml
@@ -29,6 +29,7 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="v2.0.1-revision-1" date="2024-03-26"/>
     <release version="v2.0.1" date="2023-11-15"/>
   </releases>
 </component>

--- a/org.mfek.MFEKglif.yml
+++ b/org.mfek.MFEKglif.yml
@@ -35,13 +35,19 @@ modules:
     sources:
       - type: git
         url: https://github.com/MFEK/glif.git
-        commit: 8764b3e40a6dc219f3dc7db1429c58dff9795840
+        commit: 8e73c496cba390bba7ddbad7feeb8323c294b6bb
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/rust-skia/skia-binaries/releases/download/0.62.0/skia-binaries-8cf4841aefdb295709e9-x86_64-unknown-linux-gnu-gl.tar.gz
+        url: https://github.com/rust-skia/skia-binaries/releases/download/0.70.0/skia-binaries-84208280edf3e5d111e9-x86_64-unknown-linux-gnu-gl.tar.gz
         dest-filename: skia-binaries.tar.gz
-        sha256: e4806ae8566b1cc1e7692d9c5f0e0a32754a07591db6de884c107adea1922b7a
+        sha256: a5be71c6505f4b871e8baf8fda0444dcab578367fe15f23095ba9731e68c71f2
+      - type: file
+        only-arches:
+          - aarch64
+        url: https://github.com/rust-skia/skia-binaries/releases/download/0.70.0/skia-binaries-84208280edf3e5d111e9-aarch64-unknown-linux-gnu-gl.tar.gz
+        dest-filename: skia-binaries.tar.gz
+        sha256: e591b0d2714eafb6f8147df88eba52ef5df194733a2258ff4372a185e58e96c0
       - type: file
         path: ./org.mfek.MFEKglif.metainfo.xml
       - generated-sources.json
@@ -49,10 +55,21 @@ modules:
         only-arches:
           - x86_64
         dest: rust
-        url: https://static.rust-lang.org/dist/2023-11-27/rust-nightly-x86_64-unknown-linux-gnu.tar.xz
-        sha256: 129f753431110e57c2b6860248a68da440314ffc9ffd6e122eba56180da159da
+        url: https://static.rust-lang.org/dist/2024-03-26/rust-nightly-x86_64-unknown-linux-gnu.tar.xz
+        sha256: 47f362ceff573cd393dfe7e2f3e6248e52fe0d350cbf41a5851e9ea87902242e
         x-checker-data:
           type: rust
           package: rust
           channel: nightly
           target: x86_64-unknown-linux-gnu
+      - type: archive
+        only-arches:
+          - aarch64
+        dest: rust
+        url: https://static.rust-lang.org/dist/2024-03-26/rust-nightly-aarch64-unknown-linux-gnu.tar.xz
+        sha256: ae541e6b428e7b5dad008f0d73a43dd02bca8c9f0c403169765686a18cd5a813
+        x-checker-data:
+          type: rust
+          package: rust
+          channel: nightly
+          target: aarch64-unknown-linux-gnu


### PR DESCRIPTION
If consuming the rust nightly tar ball fails, I'll switch to using the nightly-sdk since the issue appeared randomly. I only added that tar ball because maintainers wanted me to avoid using nightly due to legitimate reproducibility issues. (Building was broken on the latest nightly until only a few days ago)